### PR TITLE
Fix #7: Resolve race condition on concurrent dictionary write

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -17,11 +17,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.3.2"),
-        .package(url: "https://github.com/mxcl/version.git", from: "2.0.0"),
-        .package(url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
-        .package(url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
-        .package(url: "https://github.com/scottrhoyt/swiftytexttable.git", from: "0.9.0"),
-        .package(url: "https://github.com/onevcat/rainbow.git", from: "3.0.0"),
+        .package(name: "Version", url: "https://github.com/mxcl/version.git", from: "2.0.0"),
+        .package(name: "ShellOut", url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
+        .package(name: "Files", url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
+        .package(name: "SwiftyTextTable", url: "https://github.com/scottrhoyt/swiftytexttable.git", from: "0.9.0"),
+        .package(name: "Rainbow", url: "https://github.com/onevcat/rainbow.git", from: "3.0.0"),
     ],
     targets: [
         .target(
@@ -30,7 +30,7 @@ let package = Package(
         .target(
             name: "SwiftOutdated",
             dependencies: [
-                "ArgumentParser",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "Version",
                 "ShellOut",
                 "Files",

--- a/Sources/SwiftOutdated/ConcurrentDictionary.swift
+++ b/Sources/SwiftOutdated/ConcurrentDictionary.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+class ConcurrentDictionary<Key: Hashable, Value>: Collection {
+    private var dictionary: [Key: Value]
+    private let concurrentQueue = DispatchQueue(label: UUID().uuidString, attributes: .concurrent)
+
+    var startIndex: Dictionary<Key, Value>.Index {
+        concurrentQueue.sync {
+            self.dictionary.startIndex
+        }
+    }
+
+    var endIndex: Dictionary<Key, Value>.Index {
+        concurrentQueue.sync {
+            self.dictionary.endIndex
+        }
+    }
+
+    init(dict: [Key: Value] = [Key: Value]()) {
+        dictionary = dict
+    }
+
+    func index(after i: Dictionary<Key, Value>.Index) -> Dictionary<Key, Value>.Index {
+        concurrentQueue.sync {
+            self.dictionary.index(after: i)
+        }
+    }
+
+    subscript(key: Key) -> Value? {
+        set(newValue) {
+            concurrentQueue.async(flags: .barrier) { [weak self] in
+                self?.dictionary[key] = newValue
+            }
+        }
+        get {
+            concurrentQueue.sync {
+                self.dictionary[key]
+            }
+        }
+    }
+
+    subscript(index: Dictionary<Key, Value>.Index) -> Dictionary<Key, Value>.Element {
+        concurrentQueue.sync {
+            self.dictionary[index]
+        }
+    }
+
+    func removeValue(forKey key: Key) {
+        concurrentQueue.async(flags: .barrier) { [weak self] in
+            self?.dictionary.removeValue(forKey: key)
+        }
+    }
+
+    func removeAll() {
+        concurrentQueue.async(flags: .barrier) { [weak self] in
+            self?.dictionary.removeAll()
+        }
+    }
+}

--- a/Sources/SwiftOutdated/Outdated.swift
+++ b/Sources/SwiftOutdated/Outdated.swift
@@ -1,6 +1,6 @@
-import Foundation
-import Dispatch
 import ArgumentParser
+import Dispatch
+import Foundation
 import SwiftyTextTable
 import Version
 
@@ -30,7 +30,7 @@ public struct Outdated: ParsableCommand {
 
     func collectVersions(for resolved: Resolved) {
         let group = DispatchGroup()
-        var versions: [Pin: [Version]] = [:]
+        let versions = ConcurrentDictionary<Pin, [Version]>()
 
         for pin in resolved.object.pins where pin.hasResolvedVersion {
             group.enter()
@@ -54,7 +54,7 @@ public struct Outdated: ParsableCommand {
         semaphore.wait()
     }
 
-    func outputOutdatedPins(versions: [Pin: [Version]], ignoredPackages: [Pin]) {
+    func outputOutdatedPins(versions: ConcurrentDictionary<Pin, [Version]>, ignoredPackages: [Pin]) {
         let outdatedPins = versions
             .compactMap { pin, allVersions -> OutdatedPin? in
                 if let current = pin.version, let latest = allVersions.last, current != latest {


### PR DESCRIPTION
While a concurrent dictionariy might create a whole realm of issues in other places, I found it to solve the issue at hand in the most reliable way. Therefore I convinced myself that it is okay to use it in the limited scope of the `outdated` tool.

In my case, a SEGFAULT was always caused by concurrent `Dictionary` writes via https://github.com/kiliankoe/swift-outdated/blob/3481a6baa25146ed507fad413cddb098e7d98ba0/Sources/SwiftOutdated/Outdated.swift#L39, so I am fairly confident that this resolves #7.