### PR TITLE
Add: Mint support description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ $ brew install swift-outdated
 
 Since `swift-outdated` installs with its name, it can be called just like a subcommand of Swift itself via `swift outdated`.
 
-If you installed `swift-outdated` via Mint, it has to be called using mint like `mint run outdated`.
-
 ```
 $ swift outdated
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ Calling `swift package update` will only update to the latest available requirem
 
 This tool aims to help with that by allowing to quickly check if any requirements might be outdated, it does this by checking the remote git tags of your dependencies to see if something outside of your version requirements is available.
 
+## Installing
+
+### [Mint](https://github.com/yonaskolb/mint)
+
+swift-outdated can be installed via [Mint](https://github.com/yonaskolb/mint).
+
+```bash
+$ mint install kiliankoe/swift-outdated
+```
+
+### Homebrew
+
 `swift-outdated` can be installed via Homebrew, although for the time being via a custom tap.
 
 ```bash
@@ -18,6 +30,8 @@ $ brew install swift-outdated
 ## Usage
 
 Since `swift-outdated` installs with its name, it can be called just like a subcommand of Swift itself via `swift outdated`.
+
+If you installed `swift-outdated` via Mint, it has to be called using mint like `mint run outdated`.
 
 ```
 $ swift outdated


### PR DESCRIPTION
## Homebrew vs [Mint](https://github.com/yonaskolb/mint) in Swift development

In current `README.md`, it says `swift-outdated` looks supporting installation only via Homebrew.
Homebrew has a problem that doesn't support fixed version feature, e.g., and is hard to handle with M1 Macs.

On the other hand, [Mint](https://github.com/yonaskolb/mint) package manager can clear these problem with Homebrew, and is popular among developers who use Swift.

## Proposal and description of my diff

I realized `swift-outdated` can be installed via Mint with no code changes.
So, why don't we mention about Mint on README?

I tried to implement that by my words on `README.md`, but I'm not a native English speaker, so please comment if you feel something about it!

## Supplement

I experimented on this repository with branch `feature/swift-outdated`.
[daichikuwa0618/NotifySPMUpdatePlayground at feature/swift-outdated](https://github.com/daichikuwa0618/NotifySPMUpdatePlayground/tree/feature/swift-outdated)

You can see how it works with these commands like below because I installed old version dependency on purpose;

installation:

```
$ mint bootstrap
🌱 Finding latest version of swift-outdated
🌱 Cloning swift-outdated 0.3.2
🌱 Resolving package
🌱 Building package
🌱 Installed swift-outdated 0.3.2
🌱 Installed 1/1 package
```

running command:

```
$ mint run outdated
🌱 Finding latest version of swift-outdated
🌱 Running swift-outdated 0.3.2...
 ----------------- --------- --------
  Package           Current   Latest
 ----------------- --------- --------
  R.swift.Library   5.3.0     5.4.0
 ----------------- --------- --------
```

and you can also check working with building in Xcode since I implemented Build Phase Script.

<img width="268" alt="スクリーンショット 2021-11-16 9 34 46" src="https://user-images.githubusercontent.com/31601805/141876883-3f566064-8736-4188-80c1-88c328f4ba38.png">
