### PR TITLE
[ADD] support swift package manager 5.6 with Package.resolved json version 2

### DIFF
--- a/Sources/SwiftOutdated/OutdatedPackage.swift
+++ b/Sources/SwiftOutdated/OutdatedPackage.swift
@@ -3,13 +3,13 @@ import Version
 import SwiftyTextTable
 import Rainbow
 
-struct OutdatedPin {
+struct OutdatedPackage {
     let package: String
     let currentVersion: Version
     let latestVersion: Version
 }
 
-extension OutdatedPin: TextTableRepresentable {
+extension OutdatedPackage: TextTableRepresentable {
     static let columnHeaders = [
         "Package",
         "Current",

--- a/Sources/SwiftOutdated/Pin.swift
+++ b/Sources/SwiftOutdated/Pin.swift
@@ -1,50 +1,26 @@
 import Foundation
-import Dispatch
-import ShellOut
-import Version
 
-struct Pin: Decodable, Hashable {
+struct PinV1: Decodable {
     let package: String
     let repositoryURL: String
     let state: State
 
-    var version: Version? {
-        guard let versionStr = self.state.version, let version = Version(versionStr) else { return nil }
-        return version
-    }
-
-    struct State: Decodable, Hashable {
+    struct State: Decodable {
         let branch: String?
         let revision: String
         let version: String?
-
-        var description: String {
-            version ?? branch ?? revision
-        }
     }
+}
 
-    var hasResolvedVersion: Bool {
-        self.state.version != nil
-    }
 
-    func availableVersions() throws -> [Version] {
-        let lsRemote = try shellOut(to: "git", arguments: ["ls-remote", "--tags", self.repositoryURL])
-        return lsRemote
-            .split(separator: "\n")
-            .map {
-                $0.split(separator: "\t")
-                    .last!
-                    .trimmingCharacters(in: .whitespaces)
-                    .replacingOccurrences(of: #"refs\/tags\/(v(?=\d))?"#, with: "", options: .regularExpression)
-            }
-            .compactMap { Version($0) }
-            .sorted()
-    }
-
-    func availableVersions(completion: @escaping ([Version]?) -> Void) {
-        DispatchQueue.global().async {
-            let versions = try? self.availableVersions()
-            completion(versions)
-        }
+struct PinV2: Decodable {
+    let identity: String
+    let location: String
+    let state: State
+    
+    struct State: Decodable {
+        let branch: String?
+        let revision: String?
+        let version: String?
     }
 }

--- a/Sources/SwiftOutdated/Resolved.swift
+++ b/Sources/SwiftOutdated/Resolved.swift
@@ -1,54 +1,16 @@
 import Foundation
-import Files
 
-struct Resolved: Decodable {
+struct ResolvedV1: Decodable {
     let object: Object
     let version: Int
 
     struct Object: Decodable {
-        let pins: [Pin]
-    }
-
-    static func read() throws -> Resolved {
-        if let rootResolved = try? File(path: "Package.resolved") {
-            return try JSONDecoder().decode(Resolved.self, from: try rootResolved.read())
-        } else if let rootResolved = try? File(path: ".package.resolved") {
-            return try JSONDecoder().decode(Resolved.self, from: try rootResolved.read())
-        }
-
-        if let xcodeWorkspace = Folder.current.subfolders.first(where: { $0.name.hasSuffix("xcworkspace") }) {
-            let resolvedPath = "xcshareddata/swiftpm/Package.resolved"
-            guard xcodeWorkspace.containsFile(at: resolvedPath) else {
-                throw Error.notFound
-            }
-            let xcodeResolved = try File(path: xcodeWorkspace.path + resolvedPath)
-            return try JSONDecoder().decode(Resolved.self, from: try xcodeResolved.read())
-        }
-
-        if let xcodeProject = Folder.current.subfolders.first(where: { $0.name.hasSuffix("xcodeproj") }) {
-            let resolvedPath = "project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
-            guard xcodeProject.containsFile(at: resolvedPath) else {
-                print(xcodeProject.path)
-                print(resolvedPath)
-                throw Error.notFound
-            }
-            let xcodeResolved = try File(path: xcodeProject.path + resolvedPath)
-            return try JSONDecoder().decode(Resolved.self, from: try xcodeResolved.read())
-        }
-
-        throw Error.notFound
+        let pins: [PinV1]
     }
 }
 
-extension Resolved {
-    enum Error: Swift.Error, LocalizedError {
-        case notFound
 
-        var errorDescription: String? {
-            switch self {
-            case .notFound:
-                return "No Package.resolved found in current working tree."
-            }
-        }
-    }
+struct ResolvedV2: Decodable {
+    let pins: [PinV2]
+    let version: Int
 }

--- a/Sources/SwiftOutdated/SwiftPackage.swift
+++ b/Sources/SwiftOutdated/SwiftPackage.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Files
+import ShellOut
+import Version
+
+public struct SwiftPackage: Hashable {
+    let package: String
+    let repositoryURL: String
+    let revision: String?
+    let version: Version?
+}
+
+
+extension SwiftPackage {
+    
+    var hasResolvedVersion: Bool {
+        self.version != nil
+    }
+    
+    func availableVersions() throws -> [Version] {
+        let lsRemote = try shellOut(to: "git", arguments: ["ls-remote", "--tags", self.repositoryURL])
+        return lsRemote
+            .split(separator: "\n")
+            .map {
+                $0.split(separator: "\t")
+                    .last!
+                    .trimmingCharacters(in: .whitespaces)
+                    .replacingOccurrences(of: #"refs\/tags\/(v(?=\d))?"#, with: "", options: .regularExpression)
+            }
+            .compactMap { Version($0) }
+            .sorted()
+    }
+
+    func availableVersions(completion: @escaping ([Version]?) -> Void) {
+        DispatchQueue.global().async {
+            let versions = try? self.availableVersions()
+            completion(versions)
+        }
+    }
+    
+    static func read() throws -> [Self] {
+        
+        let file: File = try {
+            
+            if let rootResolved = try? File(path: "Package.resolved") {
+                return rootResolved
+            } else if let rootResolved = try? File(path: ".package.resolved") {
+                return rootResolved
+            }
+
+            if let xcodeWorkspace = Folder.current.subfolders.first(where: { $0.name.hasSuffix("xcworkspace") }) {
+                let resolvedPath = "xcshareddata/swiftpm/Package.resolved"
+                guard xcodeWorkspace.containsFile(at: resolvedPath) else {
+                    throw Error.notFound
+                }
+                return try File(path: xcodeWorkspace.path + resolvedPath)
+            }
+
+            if let xcodeProject = Folder.current.subfolders.first(where: { $0.name.hasSuffix("xcodeproj") }) {
+                let resolvedPath = "project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+                guard xcodeProject.containsFile(at: resolvedPath) else {
+                    print(xcodeProject.path)
+                    print(resolvedPath)
+                    throw Error.notFound
+                }
+                return try File(path: xcodeProject.path + resolvedPath)
+            }
+
+            throw Error.notFound
+        }()
+        
+        guard let data = try? file.read() else {
+            throw Error.notReadable
+        }
+        
+        if let resolvedV1 = try? JSONDecoder().decode(ResolvedV1.self, from: data) {
+            return resolvedV1.object.pins.map {
+                SwiftPackage(
+                    package: $0.package,
+                    repositoryURL: $0.repositoryURL,
+                    revision: $0.state.revision,
+                    version: Version($0.state.version ?? "")
+                )
+            }
+        } else if let resolvedV2 = try? JSONDecoder().decode(ResolvedV2.self, from: data) {
+            return resolvedV2.pins.map {
+                SwiftPackage(
+                    package: $0.identity,
+                    repositoryURL: $0.location,
+                    revision: $0.state.revision,
+                    version: Version($0.state.version ?? "")
+                )
+            }
+        } else {
+            return []
+        }
+    }
+}
+
+
+extension SwiftPackage {
+    
+    enum Error: Swift.Error, LocalizedError {
+        case notFound
+        case notReadable
+        
+        var errorDescription: String? {
+            switch self {
+            case .notFound:
+                return "No Package.resolved found in current working tree."
+            case .notReadable:
+                return "No Package.resolved read in current working tree."
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixed this issue #13. Now swift-outdated is compatible with Package.resolved JSON version 1 and 2.