### PR TITLE
Support Markdown style table rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,12 @@ Since `swift-outdated` installs with its name, it can be called just like a subc
 ```
 $ swift outdated
 
------------------------ --------- --------
- Package                 Current   Latest
------------------------ --------- --------
- Files                   4.1.1     4.2.0
- Rainbow                 3.1.5     3.2.0
- swift-argument-parser   0.0.5     0.3.2
------------------------ --------- --------
+| Package               | Current | Latest |                                                                                                                                                                   │
+|-----------------------|---------|--------|                                                                                                                                                                   │
+| Files                 | 4.1.1   | 4.2.0  |                                                                                                                                                                   │
+| Rainbow               | 3.1.5   | 4.0.1  |                                                                                                                                                                   │
+| Version               | 2.0.0   | 2.0.1  |                                                                                                                                                                   │
+| swift-argument-parser | 1.0.2   | 1.1.4  |                                                                                                                                                                   │
 ```
 
 This lists all your outdated dependencies, the currently resolved version and the latest version available in their upstream repository.

--- a/Sources/SwiftOutdated/Outdated.swift
+++ b/Sources/SwiftOutdated/Outdated.swift
@@ -5,11 +5,6 @@ import SwiftyTextTable
 import Version
 
 public struct Outdated: ParsableCommand {
-    @Flag(name: .shortAndLong, help: "Render table in Markdown style.")
-    public var markdown = false
-
-    private var isMarkdownStyle: Bool { markdown }
-
     public init() {}
 
     public static let configuration = CommandConfiguration(
@@ -77,20 +72,16 @@ public struct Outdated: ParsableCommand {
             }
         } else {
             var table = TextTable(objects: outdatedPackages)
-            let fenceMark = isMarkdownStyle ? "|" : " "
-            table.cornerFence = fenceMark
-            table.columnFence = fenceMark
 
+            // table in Markdown style.
+            table.cornerFence = "|"
             var rendered = table.render()
-
-            if isMarkdownStyle {
-                // Remove unnecessary separators for Markdown table (first and last fences).
-                rendered = rendered
-                    .components(separatedBy: "\n")
-                    .dropFirst()
-                    .dropLast(1)
-                    .joined(separator: "\n")
-            }
+            // Remove unnecessary separators for Markdown table (first and last fences).
+            rendered = rendered
+                .components(separatedBy: "\n")
+                .dropFirst()
+                .dropLast(1)
+                .joined(separator: "\n")
 
             print(rendered)
 

--- a/Sources/SwiftOutdated/Outdated.swift
+++ b/Sources/SwiftOutdated/Outdated.swift
@@ -77,9 +77,22 @@ public struct Outdated: ParsableCommand {
             }
         } else {
             var table = TextTable(objects: outdatedPackages)
-            table.cornerFence = " "
-            table.columnFence = " "
-            print(table.render())
+            let fenceMark = isMarkdownStyle ? "|" : " "
+            table.cornerFence = fenceMark
+            table.columnFence = fenceMark
+
+            var rendered = table.render()
+
+            if isMarkdownStyle {
+                // Remove unnecessary separators for Markdown table (first and last fences).
+                rendered = rendered
+                    .components(separatedBy: "\n")
+                    .dropFirst()
+                    .dropLast(1)
+                    .joined(separator: "\n")
+            }
+
+            print(rendered)
 
             if !ignoredPackages.isEmpty {
                 let ignoredString = ignoredPackages.map { $0.package }.joined(separator: ", ")

--- a/Sources/SwiftOutdated/Outdated.swift
+++ b/Sources/SwiftOutdated/Outdated.swift
@@ -5,6 +5,11 @@ import SwiftyTextTable
 import Version
 
 public struct Outdated: ParsableCommand {
+    @Flag(name: .shortAndLong, help: "Render table in Markdown style.")
+    public var markdown = false
+
+    private var isMarkdownStyle: Bool { markdown }
+
     public init() {}
 
     public static let configuration = CommandConfiguration(


### PR DESCRIPTION
## Why?

- there are some softwares which outputs as GitHub comment
  - e.g., [danger/swift: ⚠️ Stop saying "you forgot to …" in code review](https://github.com/danger/swift)
- `SwiftyTextTable` doesn't support Markdown style

## What I did

- Add `-m` / `--markdown` option and its description for `--help` e58699c1a24fb13aa6570907a8499108041e968b
- Style table in Markdown with `--markdown` option 8e896caae30ee1da8fa870ab7eb72da03a19b2b0

## Screenshots

help command

```sh
.build/debug/swift-outdated -h
OVERVIEW: Check for outdated dependencies.

swift-outdated will output an overview of your outdated dependencies found in your Package.resolved file.
Dependencies pinned to specific revisions or branches are ignored (and shown as such).

The latest version for dependencies one major version behind is colored green, yellow for two major versions
and red for anything above that.

swift-outdated automatically detects if it is run via an Xcode run script phase and will emit warnings for
Xcode's issue navigator.

USAGE: swift outdated [--markdown]

OPTIONS:
  -m, --markdown          Render table in Markdown style.
  --version               Show the version.
  -h, --help              Show help information.
```

w/o option (nothing changes)

```sh
.build/debug/swift-outdated
 ----------------------- --------- --------
  Package                 Current   Latest
 ----------------------- --------- --------
  Files                   4.1.1     4.2.0
  Rainbow                 3.1.5     4.0.1
  Version                 2.0.0     2.0.1
  swift-argument-parser   1.0.2     1.1.4
 ----------------------- --------- --------
```

w/ `-m` option (short style)

```sh
.build/debug/swift-outdated -m
| Package               | Current | Latest |
|-----------------------|---------|--------|
| Files                 | 4.1.1   | 4.2.0  |
| Rainbow               | 3.1.5   | 4.0.1  |
| Version               | 2.0.0   | 2.0.1  |
| swift-argument-parser | 1.0.2   | 1.1.4  |
```

w/ `--markdown` option (long style)

```sh
.build/debug/swift-outdated --markdown
| Package               | Current | Latest |
|-----------------------|---------|--------|
| Files                 | 4.1.1   | 4.2.0  |
| Rainbow               | 3.1.5   | 4.0.1  |
| Version               | 2.0.0   | 2.0.1  |
| swift-argument-parser | 1.0.2   | 1.1.4  |
```