### PR TITLE
Add argument for the search directory of the Package.resolved file

### DIFF
--- a/Sources/SwiftOutdated/SwiftOutdated.swift
+++ b/Sources/SwiftOutdated/SwiftOutdated.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Dispatch
+import Files
 import Foundation
 import Logging
 import Outdated
@@ -27,6 +28,9 @@ public struct SwiftOutdated: AsyncParsableCommand {
     @Flag(name: .short, help: "Verbose output.")
     var verbose: Bool = false
 
+    @Argument(help: "The directory containing the Package.resolved file", completion: .directory)
+    var path: String = ""
+
     public static let configuration = CommandConfiguration(
         commandName: "swift-outdated",
         abstract: "Check for outdated dependencies.",
@@ -45,7 +49,7 @@ public struct SwiftOutdated: AsyncParsableCommand {
 
     public func run() async throws {
         setupLogging()
-        let pins = try SwiftPackage.currentPackagePins()
+        let pins = try SwiftPackage.currentPackagePins(in: Folder(path: path))
         let packages = await collectVersions(for: pins)
         output(packages)
     }


### PR DESCRIPTION
Previously, when `swift-outdated` was run in a directory that contained multiple `xcworkspace` or `xcodeproj` files it would silently select one of them, and it was impossible to change which one `swift-outdated` selected.

This PR adds an optional path argument used to specify what parent directory `swift-outdated` searches within to find the `Package.resolved` file. So you can run `swift-outdated Project1.xcodeproj` to find outdated packages within the `Project1` project. 

Also, when `swift-outdated` finds multiple `Package.resolved` it reports that multiple were found and which one it auto-selected.