### PR TITLE
Move all functionality into library target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,6 @@ let package = Package(
                 "Outdated",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Logging", package: "swift-log"),
-                "Version",
-                "SwiftyTextTable",
             ]
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ $ swift outdated
 
 This lists all your outdated dependencies, the currently resolved version and the latest version available in their upstream repository.
 
+### Library
+
+This packages also exposes a library target called `Outdated`. Use this if you want to integrate the functionality into your project.
+
+Here's a basic usage example.
+
+```swift
+import Outdated
+
+let pins = try SwiftPackage.currentPackagePins(in: .current)
+let packages = await SwiftPackage.collectVersions(for: pins, ignoringPrerelease: true)
+packages.output(format: .markdown)
+```
+
 ### Xcode
 
 `swift-outdated` also supports Xcode projects that use Swift packages for their dependency management. Either run it manually inside your repo

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftyTextTable
+
+public struct PackageCollection: Encodable {
+    public var outdatedPackages: [OutdatedPackage]
+    public var ignoredPackages: [SwiftPackage]
+}
+
+extension PackageCollection {
+    public enum OutputFormat: String {
+        case markdown
+        case json
+        case xcode
+    }
+
+    public func output(format: OutputFormat) {
+        guard !self.outdatedPackages.isEmpty || !self.ignoredPackages.isEmpty else { return }
+
+        switch format {
+        case .xcode:
+            self.outdatedPackages.forEach {
+                print("warning: Dependency \"\($0.package)\" is outdated (\($0.currentVersion) < \($0.latestVersion)) → \($0.url)")
+            }
+        case .json:
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            let json = try! encoder.encode(self)
+            print(String(data: json, encoding: .utf8)!)
+        case .markdown:
+            var table = TextTable(objects: self.outdatedPackages)
+
+            // table in Markdown style.
+            table.cornerFence = "|"
+            var rendered = table.render()
+            // Remove unnecessary separators for Markdown table (first and last fences).
+            rendered = rendered
+                .components(separatedBy: "\n")
+                .dropFirst()
+                .dropLast(1)
+                .joined(separator: "\n")
+
+            print(rendered)
+
+            if !self.ignoredPackages.isEmpty {
+                let ignoredString = self.ignoredPackages.map { $0.package }.joined(separator: ", ")
+                print("Ignored because of revision or branch pins: \(ignoredString)")
+            }
+        }
+    }
+}

--- a/Sources/SwiftOutdated/PackageCollection.swift
+++ b/Sources/SwiftOutdated/PackageCollection.swift
@@ -1,7 +1,0 @@
-import Foundation
-import Outdated
-
-struct PackageCollection: Encodable {
-    var outdatedPackages: [OutdatedPackage]
-    var ignoredPackages: [SwiftPackage]
-}

--- a/Sources/SwiftOutdated/SwiftOutdated.swift
+++ b/Sources/SwiftOutdated/SwiftOutdated.swift
@@ -4,8 +4,6 @@ import Files
 import Foundation
 import Logging
 import Outdated
-import SwiftyTextTable
-import Version
 
 let log = Logger(label: "SwiftOutdated")
 
@@ -13,14 +11,8 @@ let log = Logger(label: "SwiftOutdated")
 public struct SwiftOutdated: AsyncParsableCommand {
     public init() {}
 
-    enum OutputFormat: String, ExpressibleByArgument {
-        case markdown
-        case json
-        case xcode
-    }
-
     @Option(name: .shortAndLong, help: "The output format (markdown, json, xcode).")
-    var format: OutputFormat = .markdown
+    var format: CLIOutputFormat = .markdown
 
     @Flag(name: .shortAndLong, help: "Ignore pre-release versions.")
     var ignorePrerelease: Bool = false
@@ -50,96 +42,8 @@ public struct SwiftOutdated: AsyncParsableCommand {
     public func run() async throws {
         setupLogging()
         let pins = try SwiftPackage.currentPackagePins(in: Folder(path: path))
-        let packages = await collectVersions(for: pins)
-        output(packages)
-    }
-
-    func collectVersions(for packages: [SwiftPackage]) async -> PackageCollection {
-        log.info("Collecting versions for \(packages.map { $0.package }.joined(separator: ", ")).")
-        let versions = await withTaskGroup(of: (SwiftPackage, [Version]?).self) { group in
-            for package in packages where package.hasResolvedVersion {
-                log.info("Package \(package.package) has resolved version, queueing version fetch.")
-                group.addTask {
-                    let availableVersions = package.availableVersions()
-                    log.info("Found \(availableVersions.count) versions for \(package.package).")
-                    return (package, availableVersions)
-                }
-            }
-
-            var availableVersions = [SwiftPackage: [Version]]()
-            for await (package, versions) in group {
-                if let versions = versions {
-                    availableVersions[package] = versions
-                }
-            }
-
-            return availableVersions
-        }
-
-        let outdatedPackages = versions
-            .compactMap { package, allVersions -> OutdatedPackage? in
-                if let current = package.version, let latest = getLatestVersion(from: allVersions), current != latest {
-                    log.info("Package \(package.package) is outdated.")
-                    return OutdatedPackage(package: package.package, currentVersion: current, latestVersion: latest, url: package.repositoryURL)
-                } else {
-                    log.info("Package \(package.package) is up to date.")
-                }
-                return nil
-            }
-            .sorted(by: { $0.package < $1.package })
-        let ignoredPackages = packages.filter { !$0.hasResolvedVersion }
-        if !ignoredPackages.isEmpty {
-            log.info("Ignoring \(ignoredPackages.map { $0.package }.joined(separator: ", ")) because of non-version pins.")
-        }
-        return PackageCollection(outdatedPackages: outdatedPackages, ignoredPackages: ignoredPackages)
-    }
-
-    private func getLatestVersion(from allVersions: [Version]) -> Version? {
-        if ignorePrerelease {
-            return allVersions.last(where: { $0.prereleaseIdentifiers.isEmpty })
-        } else {
-            return allVersions.last
-        }
-    }
-
-    func output(_ packages: PackageCollection) {
-        guard !packages.outdatedPackages.isEmpty || !packages.ignoredPackages.isEmpty else { return }
-
-        var outputFormat = format
-        if isRunningInXcode {
-            outputFormat = .xcode
-        }
-
-        switch outputFormat {
-        case .xcode:
-            packages.outdatedPackages.forEach {
-                print("warning: Dependency \"\($0.package)\" is outdated (\($0.currentVersion) < \($0.latestVersion)) → \($0.url)")
-            }
-        case .json:
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .prettyPrinted
-            let json = try! encoder.encode(packages)
-            print(String(data: json, encoding: .utf8)!)
-        case .markdown:
-            var table = TextTable(objects: packages.outdatedPackages)
-
-            // table in Markdown style.
-            table.cornerFence = "|"
-            var rendered = table.render()
-            // Remove unnecessary separators for Markdown table (first and last fences).
-            rendered = rendered
-                .components(separatedBy: "\n")
-                .dropFirst()
-                .dropLast(1)
-                .joined(separator: "\n")
-
-            print(rendered)
-
-            if !packages.ignoredPackages.isEmpty {
-                let ignoredString = packages.ignoredPackages.map { $0.package }.joined(separator: ", ")
-                print("Ignored because of revision or branch pins: \(ignoredString)")
-            }
-        }
+        let packages = await SwiftPackage.collectVersions(for: pins, ignoringPrerelease: ignorePrerelease)
+        packages.output(format: isRunningInXcode ? .xcode : format.libFormat)
     }
 
     private var isRunningInXcode: Bool {
@@ -160,5 +64,15 @@ public struct SwiftOutdated: AsyncParsableCommand {
             }
             return logHandler
         }
+    }
+}
+
+enum CLIOutputFormat: String, ExpressibleByArgument {
+    case markdown
+    case json
+    case xcode
+
+    var libFormat: PackageCollection.OutputFormat {
+        .init(rawValue: self.rawValue)! // lol
     }
 }


### PR DESCRIPTION
This moves all logic from the CLI command into the library target for easier integration into other tools.

Instead of collecting the version information into a package collection and outputting that according to a specific format identifier, it now comes down to something like this.

```swift
import Outdated

let pins = try SwiftPackage.currentPackagePins(in: .current)
let packages = await SwiftPackage.collectVersions(for: pins, ignoringPrerelease: true)
packages.output(format: .markdown)
```