### PR TITLE
feat: Add support for Tuist-managed dependencies

### DIFF
--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -90,7 +90,8 @@ extension SwiftPackage {
                 "Package.resolved",
                 ".package.resolved",
                 "xcshareddata/swiftpm/Package.resolved",
-                "project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+                "project.xcworkspace/xcshareddata/swiftpm/Package.resolved",
+                "Tuist/Package.resolved"
             ]
             if let resolvedPath = possibleRootResolvedPaths.lazy.compactMap({ try? folder.file(at: $0) }).first {
                 log.info("Found package pins at \(resolvedPath.path(relativeTo: folder))")


### PR DESCRIPTION
This PR adds `Tuist/Package.resolved` to the search paths, enabling `swift-outdated` to detect dependencies in Tuist projects.

### Motivation
Tuist projects store their direct dependencies in `Tuist/Package.resolved`, while the workspace `Package.resolved` often only contains transitive dependencies. Without this change, tools running on Tuist projects miss direct dependencies like Sentry or Superwall defined in `Tuist/Dependencies.swift`.

### Changes
- Added `Tuist/Package.resolved` to the `possibleRootResolvedPaths` list in `SwiftPackage.swift`.

Tested locally on a Tuist project and verified it now correctly picks up all dependencies.