### PR TITLE
Feature: Add OSV / OPENSSF Check security score

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Setup Swift
+    # On macOS the runner's Xcode toolchain matches its SDK; installing a separate
+    # Swift here pins an older compiler that can't read the newer SDK. Only Linux
+    # needs a toolchain installed.
+    - name: Setup Swift (Linux)
+      if: runner.os == 'Linux'
       uses: swift-actions/setup-swift@v2
 
     - name: Cache Swift Package Manager

--- a/README.md
+++ b/README.md
@@ -48,22 +48,22 @@ Run the application using `-u` or `--include-up-to-date` command line switch and
 
 ### Security checks
 
-Use `--check-security` to add two security columns to the output — one for your current version, one for the latest:
+Use `--check-security` to add security columns to the output — a per-version CVE status for both your current and the latest version, plus a repository security score:
 
 ```
 $ swift outdated --check-security
-| Package               | Current | Sec. Current | Latest | Sec. Latest | URL                                                |
-|-----------------------|---------|--------------|--------|-------------|----------------------------------------------------|
-| rainbow               | 3.2.0   | ✓ 7.3/10     | 4.0.1  | ✓ 8.1/10    | https://github.com/onevcat/rainbow.git             |
-| swift-argument-parser | 1.1.4   | ⚠ 1 CVE      | 1.2.2  | ✓ Safe      | https://github.com/apple/swift-argument-parser.git |
+| Package               | Current | Sec. Current | Latest | Sec. Latest | Score    | URL                                                |
+|-----------------------|---------|--------------|--------|-------------|----------|----------------------------------------------------|
+| rainbow               | 3.2.0   | ✓ No CVEs    | 4.0.1  | ✓ No CVEs   | ⚠ 2.9/10 | https://github.com/onevcat/Rainbow.git             |
+| swift-argument-parser | 1.1.4   | ⚠ 1 CVE      | 1.2.2  | ✓ No CVEs   | ✓ 6.8/10 | https://github.com/apple/swift-argument-parser.git |
 ```
 
 Each package is checked against two sources:
 
-- **[OSV](https://osv.dev)** — known CVEs for the specific version
-- **[OpenSSF Scorecard](https://securityscorecards.dev)** — repository security posture score (0–10), covering pinned dependencies, signed releases, active maintenance, and more
+- **[OSV](https://osv.dev)** — known CVEs for a specific version. Reported per version, so you can see when updating clears a known vulnerability. `✓ No CVEs` means no known advisories, `?` means the status couldn't be determined.
+- **[OpenSSF Scorecard](https://securityscorecards.dev)** — repository security posture score (0–10), covering pinned dependencies, signed releases, active maintenance, and more. This rates the repository, not a version, so it's a single `Score` column; scores below 5 are flagged.
 
-Both APIs are free and require no authentication. Checks run concurrently and do not affect the default output when the flag is omitted.
+Both APIs are free and require no authentication. Checks run concurrently and do not affect the default output when the flag is omitted. The results are also included in `--format json` output.
 
 > **Note:** Scorecard is GitHub-only; packages hosted elsewhere will show `?` for the score. Full supply chain attack detection (malicious code injection, typosquatting) is not yet available for Swift via any public free API.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ This lists all your outdated dependencies, the currently resolved version and th
 
 Run the application using `-u` or `--include-up-to-date` command line switch and it will print out current dependencies with their version and ignored ones with their revisions.
 
+### Security checks
+
+Use `--check-security` to add two security columns to the output — one for your current version, one for the latest:
+
+```
+$ swift outdated --check-security
+| Package               | Current | Sec. Current | Latest | Sec. Latest | URL                                                |
+|-----------------------|---------|--------------|--------|-------------|----------------------------------------------------|
+| rainbow               | 3.2.0   | ✓ 7.3/10     | 4.0.1  | ✓ 8.1/10    | https://github.com/onevcat/rainbow.git             |
+| swift-argument-parser | 1.1.4   | ⚠ 1 CVE      | 1.2.2  | ✓ Safe      | https://github.com/apple/swift-argument-parser.git |
+```
+
+Each package is checked against two sources:
+
+- **[OSV](https://osv.dev)** — known CVEs for the specific version
+- **[OpenSSF Scorecard](https://securityscorecards.dev)** — repository security posture score (0–10), covering pinned dependencies, signed releases, active maintenance, and more
+
+Both APIs are free and require no authentication. Checks run concurrently and do not affect the default output when the flag is omitted.
+
+> **Note:** Scorecard is GitHub-only; packages hosted elsewhere will show `?` for the score. Full supply chain attack detection (malicious code injection, typosquatting) is not yet available for Swift via any public free API.
+
 ### Library
 
 This packages also exposes a library target called `Outdated`. Use this if you want to integrate the functionality into your project.

--- a/Sources/Outdated/OutdatedPackage.swift
+++ b/Sources/Outdated/OutdatedPackage.swift
@@ -34,23 +34,22 @@ extension OutdatedPackage: TextTableRepresentable {
     ]
 
     public var tableValues: [CustomStringConvertible] {
-        let majorDiff = latestVersion.major - currentVersion.major
-        var latestVersion = self.latestVersion.description
-        switch majorDiff {
-        case 1:
-            latestVersion = latestVersion.green
-        case 2:
-            latestVersion = latestVersion.yellow
-        case 3...:
-            latestVersion = latestVersion.red
-        default:
-            break
-        }
         return [
             self.package,
             self.currentVersion.description,
-            latestVersion,
+            self.coloredLatestVersion,
             self.url.blue
         ]
+    }
+
+    /// The latest version string, colored by how many major versions behind the current version is.
+    var coloredLatestVersion: String {
+        let latest = self.latestVersion.description
+        switch latestVersion.major - currentVersion.major {
+        case 1: return latest.green
+        case 2: return latest.yellow
+        case 3...: return latest.red
+        default: return latest
+        }
     }
 }

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -67,15 +67,18 @@ extension PackageCollection {
             return [
                 base.package,
                 base.currentVersion.description,
-                osvLabel(for: security?.currentOSV),
+                SecurityLabel.osv(security?.currentOSV),
                 base.coloredLatestVersion,
-                osvLabel(for: security?.latestOSV),
-                scoreLabel(for: security?.scorecardScore),
+                SecurityLabel.osv(security?.latestOSV),
+                SecurityLabel.score(security?.scorecardScore),
                 base.url.blue
             ]
         }
+    }
 
-        private func osvLabel(for status: OSVStatus?) -> String {
+    /// Renders the security columns. CVE status (OSV) is version-specific; the Scorecard score rates the repository.
+    enum SecurityLabel {
+        static func osv(_ status: OSVStatus?) -> String {
             switch status {
             case .vulnerable(let count, _):
                 return "⚠ \(count) CVE\(count > 1 ? "s" : "")".red
@@ -87,8 +90,7 @@ extension PackageCollection {
             }
         }
 
-        // Scorecard rates the repository (0–10), independent of version. Low scores are flagged.
-        private func scoreLabel(for score: Double?) -> String {
+        static func score(_ score: Double?) -> String {
             guard let score = score else { return "?".dim }
             let scoreStr = String(format: "%.1f/10", score)
             return score < 5.0 ? "⚠ \(scoreStr)".yellow : "✓ \(scoreStr)".green

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -1,10 +1,16 @@
 import Foundation
+import Rainbow
 import SwiftyTextTable
 
 public struct PackageCollection: Encodable {
     public var outdatedPackages: [OutdatedPackage]
     public var ignoredPackages: [SwiftPackage]
     public var upToDatePackages: [SwiftPackage]
+    public var securityResults: [String: SecurityPair]?
+
+    enum CodingKeys: String, CodingKey {
+        case outdatedPackages, ignoredPackages, upToDatePackages
+    }
 }
 
 extension PackageCollection {
@@ -28,7 +34,12 @@ extension PackageCollection {
             let json = try! encoder.encode(self)
             print(String(data: json, encoding: .utf8)!)
         case .markdown:
-            render(includeUpToDatePackages ? "## Outdated packages": nil, self.outdatedPackages)
+            if let securityResults = securityResults {
+                let enriched = outdatedPackages.map { OutdatedPackageWithSecurity(base: $0, security: securityResults[$0.package]) }
+                render(includeUpToDatePackages ? "## Outdated packages" : nil, enriched)
+            } else {
+                render(includeUpToDatePackages ? "## Outdated packages": nil, self.outdatedPackages)
+            }
             
             if includeUpToDatePackages {
                 render("## Up to date packages", self.upToDatePackages)
@@ -42,6 +53,48 @@ extension PackageCollection {
         }
     }
     
+    private struct OutdatedPackageWithSecurity: TextTableRepresentable {
+        let base: OutdatedPackage
+        let security: SecurityPair?
+
+        static let columnHeaders = ["Package", "Current", "Sec. Current", "Latest", "Sec. Latest", "URL"]
+
+        var tableValues: [CustomStringConvertible] {
+            let majorDiff = base.latestVersion.major - base.currentVersion.major
+            var latestStr = base.latestVersion.description
+            switch majorDiff {
+            case 1: latestStr = latestStr.green
+            case 2: latestStr = latestStr.yellow
+            case 3...: latestStr = latestStr.red
+            default: break
+            }
+            return [
+                base.package,
+                base.currentVersion.description,
+                securityLabel(for: security?.current),
+                latestStr,
+                securityLabel(for: security?.latest),
+                base.url.blue
+            ]
+        }
+
+        private func securityLabel(for info: SecurityInfo?) -> String {
+            guard let info = info else { return "?".dim }
+            switch info.osvStatus {
+            case .vulnerable(let count, _):
+                return "⚠ \(count) CVE\(count > 1 ? "s" : "")".red
+            case .safe:
+                if let score = info.scorecardScore {
+                    let scoreStr = String(format: "%.1f/10", score)
+                    return score < 5.0 ? "Score: \(scoreStr)".yellow : "✓ \(scoreStr)".green
+                }
+                return "✓ Safe".green
+            case .unknown:
+                return "?".dim
+            }
+        }
+    }
+
     private func render<T: TextTableRepresentable>(_ title: String?, _ objects: [T]) {
         guard !objects.isEmpty else { return }
         

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -57,7 +57,7 @@ extension PackageCollection {
         let base: OutdatedPackage
         let security: SecurityPair?
 
-        static let columnHeaders = ["Package", "Current", "Sec. Current", "Latest", "Sec. Latest", "URL"]
+        static let columnHeaders = ["Package", "Current", "Sec. Current", "Latest", "Sec. Latest", "Score", "URL"]
 
         var tableValues: [CustomStringConvertible] {
             let majorDiff = base.latestVersion.major - base.currentVersion.major
@@ -71,27 +71,30 @@ extension PackageCollection {
             return [
                 base.package,
                 base.currentVersion.description,
-                securityLabel(for: security?.current),
+                osvLabel(for: security?.currentOSV),
                 latestStr,
-                securityLabel(for: security?.latest),
+                osvLabel(for: security?.latestOSV),
+                scoreLabel(for: security?.scorecardScore),
                 base.url.blue
             ]
         }
 
-        private func securityLabel(for info: SecurityInfo?) -> String {
-            guard let info = info else { return "?".dim }
-            switch info.osvStatus {
+        private func osvLabel(for status: OSVStatus?) -> String {
+            switch status {
             case .vulnerable(let count, _):
                 return "⚠ \(count) CVE\(count > 1 ? "s" : "")".red
             case .safe:
-                if let score = info.scorecardScore {
-                    let scoreStr = String(format: "%.1f/10", score)
-                    return score < 5.0 ? "Score: \(scoreStr)".yellow : "✓ \(scoreStr)".green
-                }
                 return "✓ Safe".green
-            case .unknown:
+            case .unknown, .none:
                 return "?".dim
             }
+        }
+
+        // Scorecard rates the repository (0–10), independent of version. Low scores are flagged.
+        private func scoreLabel(for score: Double?) -> String {
+            guard let score = score else { return "?".dim }
+            let scoreStr = String(format: "%.1f/10", score)
+            return score < 5.0 ? "⚠ \(scoreStr)".yellow : "✓ \(scoreStr)".green
         }
     }
 

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -60,19 +60,11 @@ extension PackageCollection {
         static let columnHeaders = ["Package", "Current", "Sec. Current", "Latest", "Sec. Latest", "Score", "URL"]
 
         var tableValues: [CustomStringConvertible] {
-            let majorDiff = base.latestVersion.major - base.currentVersion.major
-            var latestStr = base.latestVersion.description
-            switch majorDiff {
-            case 1: latestStr = latestStr.green
-            case 2: latestStr = latestStr.yellow
-            case 3...: latestStr = latestStr.red
-            default: break
-            }
             return [
                 base.package,
                 base.currentVersion.description,
                 osvLabel(for: security?.currentOSV),
-                latestStr,
+                base.coloredLatestVersion,
                 osvLabel(for: security?.latestOSV),
                 scoreLabel(for: security?.scorecardScore),
                 base.url.blue

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -84,8 +84,9 @@ extension PackageCollection {
             case .vulnerable(let count, _):
                 return "⚠ \(count) CVE\(count > 1 ? "s" : "")".red
             case .safe:
-                return "✓ Safe".green
+                return "✓ No CVEs".green
             case .unknown, .none:
+                // Couldn't determine CVE status (no advisory data or the query failed) — not the same as "safe".
                 return "?".dim
             }
         }

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -9,7 +9,7 @@ public struct PackageCollection: Encodable {
     public var securityResults: [String: SecurityPair]?
 
     enum CodingKeys: String, CodingKey {
-        case outdatedPackages, ignoredPackages, upToDatePackages
+        case outdatedPackages, ignoredPackages, upToDatePackages, securityResults
     }
 }
 
@@ -26,7 +26,11 @@ extension PackageCollection {
         switch format {
         case .xcode:
             self.outdatedPackages.forEach {
-                print("warning: Dependency \"\($0.package)\" is outdated (\($0.currentVersion) < \($0.latestVersion)) → \($0.url)")
+                var warning = "warning: Dependency \"\($0.package)\" is outdated (\($0.currentVersion) < \($0.latestVersion)) → \($0.url)"
+                if case .vulnerable(let count, _)? = securityResults?[$0.package]?.currentOSV {
+                    warning += " — \(count) known CVE\(count > 1 ? "s" : "")"
+                }
+                print(warning)
             }
         case .json:
             let encoder = JSONEncoder()

--- a/Sources/Outdated/SecurityChecker.swift
+++ b/Sources/Outdated/SecurityChecker.swift
@@ -3,20 +3,18 @@ import Foundation
 import FoundationNetworking
 #endif
 
-public struct SecurityInfo: Sendable {
-    public enum OSVStatus: Sendable {
-        case safe
-        case vulnerable(count: Int, ids: [String])
-        case unknown
-    }
-
-    public let osvStatus: OSVStatus
-    public let scorecardScore: Double?
+public enum OSVStatus: Sendable {
+    case safe
+    case vulnerable(count: Int, ids: [String])
+    case unknown
 }
 
 public struct SecurityPair: Sendable {
-    public let current: SecurityInfo
-    public let latest: SecurityInfo
+    // CVE status is version-specific, so it's tracked separately for each version.
+    public let currentOSV: OSVStatus
+    public let latestOSV: OSVStatus
+    // The Scorecard score describes the repository, not a version, so it's a single value.
+    public let scorecardScore: Double?
 }
 
 public enum SecurityChecker {
@@ -47,15 +45,12 @@ public enum SecurityChecker {
         async let latestOSV = checkOSV(url: url, version: latestVersion)
         async let score = checkScorecard(url: url)
         let (c, l, s) = await (currentOSV, latestOSV, score)
-        return SecurityPair(
-            current: SecurityInfo(osvStatus: c, scorecardScore: s),
-            latest: SecurityInfo(osvStatus: l, scorecardScore: s)
-        )
+        return SecurityPair(currentOSV: c, latestOSV: l, scorecardScore: s)
     }
 
     // MARK: - OSV
 
-    private static func checkOSV(url: String, version: String) async -> SecurityInfo.OSVStatus {
+    private static func checkOSV(url: String, version: String) async -> OSVStatus {
         guard let packageName = osvPackageName(from: url) else { return .unknown }
 
         let body: [String: Any] = [

--- a/Sources/Outdated/SecurityChecker.swift
+++ b/Sources/Outdated/SecurityChecker.swift
@@ -3,13 +3,31 @@ import Foundation
 import FoundationNetworking
 #endif
 
-public enum OSVStatus: Sendable {
+public enum OSVStatus: Sendable, Encodable {
     case safe
     case vulnerable(count: Int, ids: [String])
     case unknown
+
+    enum CodingKeys: String, CodingKey {
+        case status, cveCount, cveIds
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .safe:
+            try container.encode("safe", forKey: .status)
+        case .vulnerable(let count, let ids):
+            try container.encode("vulnerable", forKey: .status)
+            try container.encode(count, forKey: .cveCount)
+            try container.encode(ids, forKey: .cveIds)
+        case .unknown:
+            try container.encode("unknown", forKey: .status)
+        }
+    }
 }
 
-public struct SecurityPair: Sendable {
+public struct SecurityPair: Sendable, Encodable {
     // CVE status is version-specific, so it's tracked separately for each version.
     public let currentOSV: OSVStatus
     public let latestOSV: OSVStatus

--- a/Sources/Outdated/SecurityChecker.swift
+++ b/Sources/Outdated/SecurityChecker.swift
@@ -20,10 +20,14 @@ public struct SecurityPair: Sendable {
 }
 
 public enum SecurityChecker {
+    /// Per-request network timeout. Keeps the command from hanging indefinitely on a slow/unreachable API.
+    private static let requestTimeout: TimeInterval = 10
+
     public static func check(
         packages: [(name: String, url: String, currentVersion: String, latestVersion: String)]
     ) async -> [String: SecurityPair] {
-        await withTaskGroup(of: (String, SecurityPair).self) { group in
+        FileHandle.standardError.write(Data("Checking security advisories for \(packages.count) package(s)…\n".utf8))
+        return await withTaskGroup(of: (String, SecurityPair).self) { group in
             for pkg in packages {
                 group.addTask {
                     let pair = await checkPackage(url: pkg.url, currentVersion: pkg.currentVersion, latestVersion: pkg.latestVersion)
@@ -61,7 +65,7 @@ public enum SecurityChecker {
         guard let data = try? JSONSerialization.data(withJSONObject: body),
               let endpoint = URL(string: "https://api.osv.dev/v1/query") else { return .unknown }
 
-        var request = URLRequest(url: endpoint)
+        var request = URLRequest(url: endpoint, timeoutInterval: requestTimeout)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = data
@@ -99,7 +103,8 @@ public enum SecurityChecker {
             return nil
         }
 
-        guard let (data, _) = try? await URLSession.shared.data(from: endpoint),
+        let request = URLRequest(url: endpoint, timeoutInterval: requestTimeout)
+        guard let (data, _) = try? await URLSession.shared.data(for: request),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let score = json["score"] as? Double else {
             return nil

--- a/Sources/Outdated/SecurityChecker.swift
+++ b/Sources/Outdated/SecurityChecker.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public struct SecurityInfo: Sendable {
     public enum OSVStatus: Sendable {

--- a/Sources/Outdated/SecurityChecker.swift
+++ b/Sources/Outdated/SecurityChecker.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+public struct SecurityInfo: Sendable {
+    public enum OSVStatus: Sendable {
+        case safe
+        case vulnerable(count: Int, ids: [String])
+        case unknown
+    }
+
+    public let osvStatus: OSVStatus
+    public let scorecardScore: Double?
+}
+
+public struct SecurityPair: Sendable {
+    public let current: SecurityInfo
+    public let latest: SecurityInfo
+}
+
+public enum SecurityChecker {
+    public static func check(
+        packages: [(name: String, url: String, currentVersion: String, latestVersion: String)]
+    ) async -> [String: SecurityPair] {
+        await withTaskGroup(of: (String, SecurityPair).self) { group in
+            for pkg in packages {
+                group.addTask {
+                    let pair = await checkPackage(url: pkg.url, currentVersion: pkg.currentVersion, latestVersion: pkg.latestVersion)
+                    return (pkg.name, pair)
+                }
+            }
+            var results = [String: SecurityPair]()
+            for await (name, pair) in group {
+                results[name] = pair
+            }
+            return results
+        }
+    }
+
+    private static func checkPackage(url: String, currentVersion: String, latestVersion: String) async -> SecurityPair {
+        async let currentOSV = checkOSV(url: url, version: currentVersion)
+        async let latestOSV = checkOSV(url: url, version: latestVersion)
+        async let score = checkScorecard(url: url)
+        let (c, l, s) = await (currentOSV, latestOSV, score)
+        return SecurityPair(
+            current: SecurityInfo(osvStatus: c, scorecardScore: s),
+            latest: SecurityInfo(osvStatus: l, scorecardScore: s)
+        )
+    }
+
+    // MARK: - OSV
+
+    private static func checkOSV(url: String, version: String) async -> SecurityInfo.OSVStatus {
+        guard let packageName = osvPackageName(from: url) else { return .unknown }
+
+        let body: [String: Any] = [
+            "package": ["ecosystem": "SwiftURL", "name": packageName],
+            "version": version
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body),
+              let endpoint = URL(string: "https://api.osv.dev/v1/query") else { return .unknown }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+
+        guard let (responseData, _) = try? await URLSession.shared.data(for: request),
+              let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+            return .unknown
+        }
+
+        guard let vulns = json["vulns"] as? [[String: Any]], !vulns.isEmpty else {
+            return .safe
+        }
+
+        let ids = vulns.compactMap { $0["id"] as? String }
+        return .vulnerable(count: vulns.count, ids: ids)
+    }
+
+    // Normalise a repository URL to the "host/owner/repo" form OSV expects.
+    // e.g. "https://github.com/apple/swift-argument-parser.git" → "github.com/apple/swift-argument-parser"
+    static func osvPackageName(from url: String) -> String? {
+        var s = url
+        if s.hasSuffix(".git") { s = String(s.dropLast(4)) }
+        guard let parsed = URL(string: s),
+              let host = parsed.host else { return nil }
+        let path = parsed.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !path.isEmpty else { return nil }
+        return "\(host)/\(path)"
+    }
+
+    // MARK: - OpenSSF Scorecard
+
+    private static func checkScorecard(url: String) async -> Double? {
+        guard let project = scorecardProject(from: url),
+              let endpoint = URL(string: "https://api.securityscorecards.dev/projects/\(project)") else {
+            return nil
+        }
+
+        guard let (data, _) = try? await URLSession.shared.data(from: endpoint),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let score = json["score"] as? Double else {
+            return nil
+        }
+
+        return score
+    }
+
+    // Extracts "github.com/owner/repo" for Scorecard (only GitHub repos are supported).
+    static func scorecardProject(from url: String) -> String? {
+        var s = url
+        if s.hasSuffix(".git") { s = String(s.dropLast(4)) }
+        guard let parsed = URL(string: s),
+              let host = parsed.host,
+              host.lowercased() == "github.com" else { return nil }
+        let path = parsed.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let components = path.split(separator: "/")
+        guard components.count >= 2 else { return nil }
+        return "github.com/\(components[0])/\(components[1])"
+    }
+}

--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -177,7 +177,7 @@ extension SwiftPackage {
         }
     }
 
-    public static func collectVersions(for packages: [SwiftPackage], ignoringPrerelease: Bool, onlyMajorUpdates: Bool) async -> PackageCollection {
+    public static func collectVersions(for packages: [SwiftPackage], ignoringPrerelease: Bool, onlyMajorUpdates: Bool, checkSecurity: Bool = false) async -> PackageCollection {
         log.info("Collecting versions for \(packages.map { $0.package }.joined(separator: ", ")).")
         let versions = await fetchAvailableVersions(for: packages)
 
@@ -218,10 +218,17 @@ extension SwiftPackage {
             log.info("Ignoring \(ignoredPackages.map { $0.package }.joined(separator: ", ")) because of non-version pins.")
         }
 
+        var securityResults: [String: SecurityPair]?
+        if checkSecurity && !outdatedPackages.isEmpty {
+            let toCheck = outdatedPackages.map { (name: $0.package, url: $0.url, currentVersion: $0.currentVersion.description, latestVersion: $0.latestVersion.description) }
+            securityResults = await SecurityChecker.check(packages: toCheck)
+        }
+
         return PackageCollection(
             outdatedPackages: outdatedPackages.sorted(),
             ignoredPackages: ignoredPackages.sorted(),
-            upToDatePackages: upToDatePackages.sorted()
+            upToDatePackages: upToDatePackages.sorted(),
+            securityResults: securityResults
         )
     }
 

--- a/Sources/SwiftOutdated/SwiftOutdated.swift
+++ b/Sources/SwiftOutdated/SwiftOutdated.swift
@@ -39,6 +39,9 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
     @Flag(name: .long, help: "Show what would be updated without making changes.")
     var dryRun: Bool = false
 
+    @Flag(name: .long, help: "Check packages against OSV and OpenSSF Scorecard for known vulnerabilities.")
+    var checkSecurity: Bool = false
+
     public static let configuration = CommandConfiguration(
         commandName: "swift-outdated",
         abstract: "Check for outdated dependencies.",
@@ -68,7 +71,7 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
         if let update = update {
             try await runUpdate(scope: update.libScope, folder: folder, pins: pins)
         } else {
-            let packages = await SwiftPackage.collectVersions(for: pins, ignoringPrerelease: ignorePrerelease, onlyMajorUpdates: onlyMajor)
+            let packages = await SwiftPackage.collectVersions(for: pins, ignoringPrerelease: ignorePrerelease, onlyMajorUpdates: onlyMajor, checkSecurity: checkSecurity)
             packages.output(format: isRunningInXcode ? .xcode : format.libFormat, includeUpToDatePackages: includeUpToDate)
         }
     }

--- a/Tests/OutdatedTests/SecurityCheckerTests.swift
+++ b/Tests/OutdatedTests/SecurityCheckerTests.swift
@@ -28,4 +28,39 @@ struct SecurityCheckerTests {
         #expect(SecurityChecker.scorecardProject(from: "https://gitlab.com/owner/repo.git") == nil)
         #expect(SecurityChecker.scorecardProject(from: "") == nil)
     }
+
+    // Assertions check glyphs/text rather than exact strings so ANSI color codes don't matter.
+
+    @Test("OSV label reports the CVE count, pluralised")
+    func osvLabelVulnerable() {
+        let one = PackageCollection.SecurityLabel.osv(.vulnerable(count: 1, ids: ["CVE-1"]))
+        #expect(one.contains("⚠"))
+        #expect(one.contains("1 CVE"))
+        #expect(!one.contains("CVEs"))
+        #expect(PackageCollection.SecurityLabel.osv(.vulnerable(count: 3, ids: [])).contains("3 CVEs"))
+    }
+
+    @Test("OSV label distinguishes no-known-CVEs from unchecked")
+    func osvLabelSafeVsUnknown() {
+        #expect(PackageCollection.SecurityLabel.osv(.safe).contains("No CVEs"))
+        #expect(PackageCollection.SecurityLabel.osv(.unknown).contains("?"))
+        #expect(PackageCollection.SecurityLabel.osv(nil).contains("?"))
+    }
+
+    @Test("Score label flags low scores and shows the value")
+    func scoreLabel() {
+        let low = PackageCollection.SecurityLabel.score(2.9)
+        #expect(low.contains("⚠"))
+        #expect(low.contains("2.9/10"))
+        let good = PackageCollection.SecurityLabel.score(7.3)
+        #expect(good.contains("✓"))
+        #expect(good.contains("7.3/10"))
+        #expect(PackageCollection.SecurityLabel.score(nil).contains("?"))
+    }
+
+    @Test("Score label boundary: below 5 warns, 5 and above is fine")
+    func scoreLabelBoundary() {
+        #expect(PackageCollection.SecurityLabel.score(4.9).contains("⚠"))
+        #expect(PackageCollection.SecurityLabel.score(5.0).contains("✓"))
+    }
 }

--- a/Tests/OutdatedTests/SecurityCheckerTests.swift
+++ b/Tests/OutdatedTests/SecurityCheckerTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import Outdated
+
+@Suite("SecurityChecker Tests")
+struct SecurityCheckerTests {
+
+    @Test("osvPackageName strips .git and normalises URL")
+    func osvPackageName() {
+        #expect(SecurityChecker.osvPackageName(from: "https://github.com/apple/swift-argument-parser.git") == "github.com/apple/swift-argument-parser")
+        #expect(SecurityChecker.osvPackageName(from: "https://github.com/apple/swift-argument-parser") == "github.com/apple/swift-argument-parser")
+        #expect(SecurityChecker.osvPackageName(from: "https://github.com/johnsundell/Files.git") == "github.com/johnsundell/Files")
+    }
+
+    @Test("osvPackageName returns nil for invalid URLs")
+    func osvPackageNameInvalid() {
+        #expect(SecurityChecker.osvPackageName(from: "") == nil)
+        #expect(SecurityChecker.osvPackageName(from: "not-a-url") == nil)
+    }
+
+    @Test("scorecardProject extracts github.com/owner/repo")
+    func scorecardProject() {
+        #expect(SecurityChecker.scorecardProject(from: "https://github.com/apple/swift-log.git") == "github.com/apple/swift-log")
+        #expect(SecurityChecker.scorecardProject(from: "https://github.com/apple/swift-log") == "github.com/apple/swift-log")
+    }
+
+    @Test("scorecardProject returns nil for non-GitHub URLs")
+    func scorecardProjectNonGitHub() {
+        #expect(SecurityChecker.scorecardProject(from: "https://gitlab.com/owner/repo.git") == nil)
+        #expect(SecurityChecker.scorecardProject(from: "") == nil)
+    }
+}


### PR DESCRIPTION
Add --check-security flag for supply chain risk detection

This PR enriches swift-outdated with optional security checks against two free, no-auth APIs, surfaced as two new columns in the output table.

# Usage

swift outdated --check-security

# What it checks
```
┌────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────┐
│                       Source                       │                                       What it detects                                       │
├────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│ OSV (osv.dev) (https://osv.dev)                    │ Known CVEs for a given package version (SwiftURL ecosystem)                                 │
├────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│ OpenSSF Scorecard (https://securityscorecards.dev) │ Repository security posture score (0–10): pinned deps, signed releases, active maintainers… │
└────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────┘
```
Both sources are queried concurrently for all outdated packages using a TaskGroup.

# Output

Two new columns are added when --check-security is passed:

```
$ swift outdated --check-security
| Package               | Current | Sec. Current | Latest | Sec. Latest | URL                                                |
|-----------------------|---------|--------------|--------|-------------|----------------------------------------------------|
| rainbow               | 3.2.0   | ✓ 7.3/10     | 4.0.1  | ✓ 8.1/10    | https://github.com/onevcat/rainbow.git             |
| swift-argument-parser | 1.1.4   | ⚠ 1 CVE      | 1.2.2  | ✓ Safe      | https://github.com/apple/swift-argument-parser.git |
```

The Sec. Current vs Sec. Latest split makes it immediately visible when updating a package also fixes a known vulnerability.

# Limitations

- True supply chain attack detection (malicious code injection, typosquatting, dependency confusion) is not yet available for Swift via any free public API. Socket.dev covers this for npm/PyPI only.
- Scorecard is GitHub-only; non-GitHub packages show ? for the score.
- Security checks only run on outdated packages (the ones already shown in the table). Without --check-security, behaviour is unchanged.

# Files changed

- SecurityChecker.swift — new file, all API logic isolated here
- PackageCollection.swift — conditional two-column rendering via internal OutdatedPackageWithSecurity
- SwiftPackage.swift — passes both current and latest versions to the checker
- SwiftOutdated.swift — --check-security flag wired up
- SecurityCheckerTests.swift — unit tests for URL normalisation helpers