### PR TITLE
Support branch/revision pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ Run the application using `-u` or `--include-up-to-date` command line switch and
 
 ### Branch and revision pins
 
-Dependencies pinned to a branch or a specific revision have no resolved version, so there's nothing to compare against a list of remote tags. `swift-outdated` instead analyzes them against the local checkout that SwiftPM and Xcode already create, showing the tag the pinned commit sits at and the latest available version:
+Dependencies pinned to a branch or a specific revision have no resolved version, so there's nothing to compare against a list of remote tags. `swift-outdated` instead analyzes them against the local checkout that SwiftPM and Xcode already create, showing the tag the pinned commit sits at and the latest available version — right alongside your version-pinned dependencies in the same table:
 
 ```
 $ swift outdated
-## Branch/revision pins
-| Package               | Pinned                  | Latest | URL                                                |
-|-----------------------|-------------------------|--------|----------------------------------------------------|
-| swift-argument-parser | main @ fd4c3b6 (v1.0.0) | v1.8.2 | https://github.com/apple/swift-argument-parser.git |
+| Package   | Current          | Latest | URL                                    |
+|-----------|------------------|--------|----------------------------------------|
+| swift-log | 1.6.4            | 1.14.0 | https://github.com/apple/swift-log.git |
+| rainbow   | 626c3d4 (v3.2.0) | 4.2.1  | https://github.com/onevcat/Rainbow.git |
 ```
 
-The `Pinned` column shows the branch (if any), the short revision, and the closest tag at or before that commit (`git describe`); `Latest` is the newest tag available upstream. This makes it obvious when a pin can move back to a normal tagged release — for example because a fix you were tracking on a branch has since shipped.
+For a ref pin, the `Current` column shows the branch (if any), the short revision, and the closest tag at or before that commit (`git describe`); `Latest` is the newest tag available upstream. This makes it obvious when a pin can move back to a normal tagged release — for example because a fix you were tracking on a branch has since shipped.
 
 This works automatically when a checkout is present. `swift-outdated` looks in `.build/checkouts` (run `swift build` or `swift package resolve` first) and in an Xcode `SourcePackages/checkouts` directory; use `--checkouts-path` to point it elsewhere. Pins without an available checkout keep the previous behavior and are listed as ignored. The analysis is also included in `--format json` output and emitted as warnings in Xcode.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ This lists all your outdated dependencies, the currently resolved version and th
 
 Run the application using `-u` or `--include-up-to-date` command line switch and it will print out current dependencies with their version and ignored ones with their revisions.
 
+### Branch and revision pins
+
+Dependencies pinned to a branch or a specific revision have no resolved version, so there's nothing to compare against a list of remote tags. `swift-outdated` instead analyzes them against the local checkout that SwiftPM and Xcode already create, showing the tag the pinned commit sits at and the latest available version:
+
+```
+$ swift outdated
+## Branch/revision pins
+| Package               | Pinned                  | Latest | URL                                                |
+|-----------------------|-------------------------|--------|----------------------------------------------------|
+| swift-argument-parser | main @ fd4c3b6 (v1.0.0) | v1.8.2 | https://github.com/apple/swift-argument-parser.git |
+```
+
+The `Pinned` column shows the branch (if any), the short revision, and the closest tag at or before that commit (`git describe`); `Latest` is the newest tag available upstream. This makes it obvious when a pin can move back to a normal tagged release — for example because a fix you were tracking on a branch has since shipped.
+
+This works automatically when a checkout is present. `swift-outdated` looks in `.build/checkouts` (run `swift build` or `swift package resolve` first) and in an Xcode `SourcePackages/checkouts` directory; use `--checkouts-path` to point it elsewhere. Pins without an available checkout keep the previous behavior and are listed as ignored. The analysis is also included in `--format json` output and emitted as warnings in Xcode.
+
 ### Security checks
 
 Use `--check-security` to add security columns to the output — a per-version CVE status for both your current and the latest version, plus a repository security score:

--- a/Sources/Outdated/CheckoutLocator.swift
+++ b/Sources/Outdated/CheckoutLocator.swift
@@ -1,0 +1,141 @@
+import Files
+import Foundation
+import ShellOut
+
+/// Locates the local package checkouts that SwiftPM (`.build/checkouts`) or Xcode
+/// (`SourcePackages/checkouts`) already create, so ref/branch-pinned dependencies can be analyzed
+/// against a real clone without cloning anything ourselves. Purely best-effort: when nothing is
+/// found it simply yields no roots and callers fall back to the existing "ignored" behavior.
+public struct CheckoutLocator: Sendable {
+    let projectFolderPath: String
+    let explicitPath: String?
+
+    public init(projectFolder: Folder, explicitPath: String? = nil) {
+        self.projectFolderPath = projectFolder.path
+        self.explicitPath = explicitPath
+    }
+
+    public init(projectFolderPath: String, explicitPath: String? = nil) {
+        self.projectFolderPath = projectFolderPath
+        self.explicitPath = explicitPath
+    }
+
+    /// Path to the checkout for the given package, or `nil` if no validated checkout exists.
+    public func findCheckout(for identity: String, repositoryURL: String) -> String? {
+        let roots = getCheckoutRoots()
+
+        // Fast path: SwiftPM usually names the checkout dir after the repo's last path component,
+        // which typically equals the identity. Match by name, then confirm via origin URL.
+        for root in roots {
+            if let match = root.subfolders.first(where: { $0.name.lowercased() == identity.lowercased() }),
+               validateCheckout(at: match.path, expectedURL: repositoryURL) {
+                return match.path
+            }
+        }
+
+        // Fallback: the dir name can diverge from the identity, so match purely by validated origin URL.
+        for root in roots {
+            for subfolder in root.subfolders where validateCheckout(at: subfolder.path, expectedURL: repositoryURL) {
+                return subfolder.path
+            }
+        }
+
+        return nil
+    }
+
+    /// Search order:
+    /// 1. Explicit `--checkouts-path` if provided (replaces all auto-detection — sole root)
+    /// 2. `.build/checkouts` (SwiftPM)
+    /// 3. `SourcePackages/checkouts` (Xcode), incl. inside a sibling `.xcodeproj`/`.xcworkspace`
+    public func getCheckoutRoots() -> [Folder] {
+        guard let projectFolder = try? Folder(path: projectFolderPath) else {
+            return []
+        }
+
+        // An explicit path replaces auto-detection entirely.
+        if let explicit = explicitPath {
+            if let folder = try? Folder(path: explicit) {
+                return [folder]
+            }
+            return []
+        }
+
+        var roots: [Folder] = []
+
+        if let swiftpmCheckouts = try? projectFolder.subfolder(at: ".build/checkouts") {
+            roots.append(swiftpmCheckouts)
+        }
+
+        if let xcodeCheckouts = try? projectFolder.subfolder(at: "SourcePackages/checkouts") {
+            roots.append(xcodeCheckouts)
+        }
+
+        let xcodeProjects = projectFolder.subfolders.filter {
+            $0.name.hasSuffix(".xcodeproj") || $0.name.hasSuffix(".xcworkspace")
+        }
+        for project in xcodeProjects {
+            let parentFolder = project.parent ?? projectFolder
+            if let xcodeCheckouts = try? parentFolder.subfolder(at: "SourcePackages/checkouts"),
+               !roots.contains(where: { $0.path == xcodeCheckouts.path }) {
+                roots.append(xcodeCheckouts)
+            }
+        }
+
+        return roots
+    }
+
+    public func hasCheckoutsAvailable() -> Bool {
+        !getCheckoutRoots().isEmpty
+    }
+
+    private func validateCheckout(at path: String, expectedURL: String) -> Bool {
+        do {
+            let originURL = try shellOut(to: "git", arguments: ["-C", path, "remote", "get-url", "origin"])
+
+            // SwiftPM/Xcode checkouts point at a local bare mirror (`.build/repositories/…` or
+            // `SourcePackages/repositories/…`); follow that one more hop to the real remote.
+            if originURL.contains(".build/repositories/") || originURL.contains("SourcePackages/repositories/") {
+                let bareRepoOrigin = try shellOut(
+                    to: "git",
+                    arguments: ["-C", originURL.trimmingCharacters(in: .whitespacesAndNewlines), "remote", "get-url", "origin"]
+                )
+                return normalizeURL(bareRepoOrigin) == normalizeURL(expectedURL)
+            }
+
+            return normalizeURL(originURL) == normalizeURL(expectedURL)
+        } catch {
+            log.trace("Failed to get origin URL for \(path): \(error)")
+            return false
+        }
+    }
+}
+
+extension CheckoutLocator {
+    /// Normalize a repository URL for comparison, e.g.
+    /// `git@github.com:user/repo.git` and `https://github.com/user/repo` both → `github.com/user/repo`.
+    func normalizeURL(_ url: String) -> String {
+        var normalized = url.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // SSH shorthand: git@host:owner/repo → host/owner/repo
+        if normalized.hasPrefix("git@") {
+            normalized = String(normalized.dropFirst(4))
+            if let colonIndex = normalized.firstIndex(of: ":") {
+                normalized = String(normalized[..<colonIndex]) + "/" + String(normalized[normalized.index(after: colonIndex)...])
+            }
+        }
+
+        if let protocolRange = normalized.range(of: "://") {
+            normalized = String(normalized[protocolRange.upperBound...])
+        }
+
+        if normalized.hasSuffix(".git") {
+            normalized = String(normalized.dropLast(4))
+        }
+
+        if normalized.hasSuffix("/") {
+            normalized = String(normalized.dropLast())
+        }
+
+        return normalized.lowercased()
+    }
+}

--- a/Sources/Outdated/GitRemoteProvider.swift
+++ b/Sources/Outdated/GitRemoteProvider.swift
@@ -7,9 +7,30 @@ public protocol GitRemoteProvider: Sendable {
 
 public struct ShellGitRemoteProvider: GitRemoteProvider {
     public init() {}
-    
+
     public func getRemoteTags(repositoryURL: String) throws -> String {
         log.trace("git ls-remote --tags \(repositoryURL)")
         return try shellOut(to: "git", arguments: ["ls-remote", "--tags", repositoryURL])
+    }
+}
+
+/// Reads information that requires a *local* clone's commit graph — distinct from
+/// `GitRemoteProvider`, which only sees `ls-remote` output and therefore has no ancestry.
+public protocol LocalGitProvider: Sendable {
+    /// The nearest tag at or before `revision` (`git describe --tags --abbrev=0`), or `nil`
+    /// when the revision has no ancestor tags.
+    func describeTag(revision: String, checkoutPath: String) throws -> String?
+}
+
+public struct ShellLocalGitProvider: LocalGitProvider {
+    public init() {}
+
+    public func describeTag(revision: String, checkoutPath: String) throws -> String? {
+        log.trace("git -C \(checkoutPath) describe --tags --abbrev=0 \(revision)")
+        let output = try shellOut(
+            to: "git",
+            arguments: ["-C", checkoutPath, "describe", "--tags", "--abbrev=0", revision]
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        return output.isEmpty ? nil : output
     }
 }

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -7,9 +7,10 @@ public struct PackageCollection: Encodable {
     public var ignoredPackages: [SwiftPackage]
     public var upToDatePackages: [SwiftPackage]
     public var securityResults: [String: SecurityPair]?
+    public var refPinnedPackages: [RefPinAnalysis] = []
 
     enum CodingKeys: String, CodingKey {
-        case outdatedPackages, ignoredPackages, upToDatePackages, securityResults
+        case outdatedPackages, ignoredPackages, upToDatePackages, securityResults, refPinnedPackages
     }
 }
 
@@ -21,7 +22,7 @@ extension PackageCollection {
     }
 
     public func output(format: OutputFormat, includeUpToDatePackages: Bool = false) {
-        guard !self.outdatedPackages.isEmpty || !self.ignoredPackages.isEmpty else { return }
+        guard !self.outdatedPackages.isEmpty || !self.ignoredPackages.isEmpty || !self.refPinnedPackages.isEmpty else { return }
 
         switch format {
         case .xcode:
@@ -31,6 +32,12 @@ extension PackageCollection {
                     warning += " — \(count) known CVE\(count > 1 ? "s" : "")"
                 }
                 print(warning)
+            }
+            self.refPinnedPackages.filter { $0.isOutdated }.forEach {
+                let pin = $0.branch.map { "branch \($0)" } ?? "a revision"
+                let base = $0.baseTag.map { " (~v\($0))" } ?? ""
+                let latest = $0.latestTag.map { "v\($0)" } ?? "a newer tag"
+                print("warning: Dependency \"\($0.package)\" is pinned to \(pin) at \($0.shortRevision)\(base) but \(latest) is available → \($0.url)")
             }
         case .json:
             let encoder = JSONEncoder()
@@ -48,11 +55,14 @@ extension PackageCollection {
             if includeUpToDatePackages {
                 render("## Up to date packages", self.upToDatePackages)
                 render("## Ignored packages", self.ignoredPackages)
+                render("## Branch/revision pins", self.refPinnedPackages)
             } else {
                 if !self.ignoredPackages.isEmpty {
                     let ignoredString = self.ignoredPackages.map { $0.package }.joined(separator: ", ")
                     print("Ignored because of revision or branch pins: \(ignoredString)")
                 }
+                // Only the pins that are actually behind a newer tag by default.
+                render("## Branch/revision pins", self.refPinnedPackages.filter { $0.isOutdated })
             }
         }
     }

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -45,24 +45,29 @@ extension PackageCollection {
             let json = try! encoder.encode(self)
             print(String(data: json, encoding: .utf8)!)
         case .markdown:
+            // Branch/revision pins share the outdated table: their "Pinned" cell sits in the Current
+            // column. Behind pins show by default; all of them when including up-to-date packages.
+            let refPins = includeUpToDatePackages ? refPinnedPackages : refPinnedPackages.filter { $0.isOutdated }
+            let title = includeUpToDatePackages ? "## Outdated packages" : nil
+
             if let securityResults = securityResults {
-                let enriched = outdatedPackages.map { OutdatedPackageWithSecurity(base: $0, security: securityResults[$0.package]) }
-                render(includeUpToDatePackages ? "## Outdated packages" : nil, enriched)
+                var rows = outdatedPackages.map { OutdatedPackageWithSecurity(base: $0, security: securityResults[$0.package]).tableValues }
+                rows += refPins.map { refPinSecurityRow($0) }
+                renderRows(title, headers: OutdatedPackageWithSecurity.columnHeaders, rows: rows)
             } else {
-                render(includeUpToDatePackages ? "## Outdated packages": nil, self.outdatedPackages)
+                var rows = outdatedPackages.map { $0.tableValues }
+                rows += refPins.map { $0.tableValues }
+                renderRows(title, headers: OutdatedPackage.columnHeaders, rows: rows)
             }
-            
+
             if includeUpToDatePackages {
                 render("## Up to date packages", self.upToDatePackages)
                 render("## Ignored packages", self.ignoredPackages)
-                render("## Branch/revision pins", self.refPinnedPackages)
             } else {
                 if !self.ignoredPackages.isEmpty {
                     let ignoredString = self.ignoredPackages.map { $0.package }.joined(separator: ", ")
                     print("Ignored because of revision or branch pins: \(ignoredString)")
                 }
-                // Only the pins that are actually behind a newer tag by default.
-                render("## Branch/revision pins", self.refPinnedPackages.filter { $0.isOutdated })
             }
         }
     }
@@ -109,11 +114,31 @@ extension PackageCollection {
 
     private func render<T: TextTableRepresentable>(_ title: String?, _ objects: [T]) {
         guard !objects.isEmpty else { return }
-        
-        var table = TextTable(objects: objects)
+        renderRows(title, headers: T.columnHeaders, rows: objects.map { $0.tableValues })
+    }
 
-        // table in Markdown style.
+    /// Ref pins aren't security-scanned, so the CVE/score cells are unknown.
+    private func refPinSecurityRow(_ analysis: RefPinAnalysis) -> [CustomStringConvertible] {
+        [
+            analysis.package,
+            analysis.currentDisplay,
+            "?".dim,
+            analysis.latestDisplay,
+            "?".dim,
+            "?".dim,
+            analysis.url.blue,
+        ]
+    }
+
+    /// Renders rows from possibly-heterogeneous sources under a shared set of headers, in the
+    /// repository's Markdown table style.
+    private func renderRows(_ title: String?, headers: [String], rows: [[CustomStringConvertible]]) {
+        guard !rows.isEmpty else { return }
+
+        var table = TextTable(columns: headers.map { TextTableColumn(header: $0) })
         table.cornerFence = "|"
+        rows.forEach { table.addRow(values: $0) }
+
         let rendered = table.render()
         // Remove unnecessary separators for Markdown table (first and last fences).
         let tableOutput = rendered
@@ -121,7 +146,7 @@ extension PackageCollection {
             .dropFirst()
             .dropLast(1)
             .joined(separator: "\n")
-        
+
         if let title {
             print(title)
         }

--- a/Sources/Outdated/RefPinAnalysis.swift
+++ b/Sources/Outdated/RefPinAnalysis.swift
@@ -38,13 +38,33 @@ public struct RefPinAnalysis: Sendable {
     /// Current pin display, e.g. `main @ abc1234 (v1.2.0)`, `abc1234 (v1.2.0)`, or just `abc1234`.
     public var currentDisplay: String {
         var display = shortRevision
-        if let branch {
+        // Only show a branch when it's a real branch name. Pinning via `.revision("<short-sha>")`
+        // makes SwiftPM record the short SHA as the "branch", which would read as "626c3d4 @ 626c3d4".
+        if let branch, !revision.hasPrefix(branch) {
             display = "\(branch) @ \(display)"
         }
         if let base = baseTag {
             display += " (v\(base))"
         }
         return display
+    }
+
+    /// Colored latest-version cell, or `N/A` when no latest tag is known. Rendered bare (no `v`
+    /// prefix) to match the version-pinned rows it shares the Latest column with.
+    public var latestDisplay: String {
+        guard let latest = latestTag else { return "N/A" }
+        var str = "\(latest)"
+        if isOutdated {
+            // Color by how many major versions the latest tag is ahead of the base, matching
+            // the main outdated table's convention.
+            switch (baseTag.map { latest.major - $0.major }) ?? 0 {
+            case 1: str = str.green
+            case 2: str = str.yellow
+            case 3...: str = str.red
+            default: break
+            }
+        }
+        return str
     }
 
     /// Whether a newer tag exists than the one the pinned revision sits at.
@@ -73,28 +93,10 @@ extension RefPinAnalysis: TextTableRepresentable {
     ]
 
     public var tableValues: [CustomStringConvertible] {
-        let latestDisplay: String
-        if let latest = latestTag {
-            var latestStr = "v\(latest)"
-            if isOutdated {
-                // Color by how many major versions the latest tag is ahead of the base, matching
-                // the main outdated table's convention.
-                switch (baseTag.map { latest.major - $0.major }) ?? 0 {
-                case 1: latestStr = latestStr.green
-                case 2: latestStr = latestStr.yellow
-                case 3...: latestStr = latestStr.red
-                default: break
-                }
-            }
-            latestDisplay = latestStr
-        } else {
-            latestDisplay = "N/A"
-        }
-
         return [
             self.package,
             self.currentDisplay,
-            latestDisplay,
+            self.latestDisplay,
             self.url.blue
         ]
     }

--- a/Sources/Outdated/RefPinAnalysis.swift
+++ b/Sources/Outdated/RefPinAnalysis.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Rainbow
+import SwiftyTextTable
+import Version
+
+/// How outdated a branch/revision-pinned dependency is. A pure value type: the `baseTag` (the tag at
+/// or before the pinned revision, via a local checkout) and `latestTag` (the newest available tag, via
+/// `ls-remote`) are computed by the caller and handed in, so this type stays trivially testable.
+public struct RefPinAnalysis: Sendable {
+    public let package: String
+    public let branch: String?
+    public let revision: String
+    public let baseTag: Version?       // Tag at or before the pinned commit
+    public let latestTag: Version?     // Latest available tag
+    public let url: String
+
+    public init(
+        package: String,
+        branch: String? = nil,
+        revision: String,
+        baseTag: Version?,
+        latestTag: Version?,
+        url: String
+    ) {
+        self.package = package
+        self.branch = branch
+        self.revision = revision
+        self.baseTag = baseTag
+        self.latestTag = latestTag
+        self.url = url
+    }
+
+    /// Short revision (first 7 characters).
+    public var shortRevision: String {
+        String(revision.prefix(7))
+    }
+
+    /// Current pin display, e.g. `main @ abc1234 (v1.2.0)`, `abc1234 (v1.2.0)`, or just `abc1234`.
+    public var currentDisplay: String {
+        var display = shortRevision
+        if let branch {
+            display = "\(branch) @ \(display)"
+        }
+        if let base = baseTag {
+            display += " (v\(base))"
+        }
+        return display
+    }
+
+    /// Whether a newer tag exists than the one the pinned revision sits at.
+    public var isOutdated: Bool {
+        guard let base = baseTag, let latest = latestTag else {
+            return false
+        }
+        return latest > base
+    }
+}
+
+extension RefPinAnalysis: Encodable {}
+
+extension RefPinAnalysis: Comparable {
+    public static func < (lhs: RefPinAnalysis, rhs: RefPinAnalysis) -> Bool {
+        lhs.package < rhs.package
+    }
+}
+
+extension RefPinAnalysis: TextTableRepresentable {
+    public static let columnHeaders = [
+        "Package",
+        "Pinned",
+        "Latest",
+        "URL"
+    ]
+
+    public var tableValues: [CustomStringConvertible] {
+        let latestDisplay: String
+        if let latest = latestTag {
+            var latestStr = "v\(latest)"
+            if isOutdated {
+                // Color by how many major versions the latest tag is ahead of the base, matching
+                // the main outdated table's convention.
+                switch (baseTag.map { latest.major - $0.major }) ?? 0 {
+                case 1: latestStr = latestStr.green
+                case 2: latestStr = latestStr.yellow
+                case 3...: latestStr = latestStr.red
+                default: break
+                }
+            }
+            latestDisplay = latestStr
+        } else {
+            latestDisplay = "N/A"
+        }
+
+        return [
+            self.package,
+            self.currentDisplay,
+            latestDisplay,
+            self.url.blue
+        ]
+    }
+}

--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -11,14 +11,17 @@ public struct SwiftPackage: Sendable {
     public let package: String
     public let repositoryURL: String
     public let revision: String?
+    /// The branch a ref pin tracks, when pinned via `.branch(_:)` rather than a bare revision.
+    public let branch: String?
     public let version: Version?
-    
+
     private let gitProvider: GitRemoteProvider
-    
-    public init(package: String, repositoryURL: String, revision: String?, version: Version?, gitProvider: GitRemoteProvider = ShellGitRemoteProvider()) {
+
+    public init(package: String, repositoryURL: String, revision: String?, branch: String? = nil, version: Version?, gitProvider: GitRemoteProvider = ShellGitRemoteProvider()) {
         self.package = package
         self.repositoryURL = repositoryURL
         self.revision = revision
+        self.branch = branch
         self.version = version
         self.gitProvider = gitProvider
     }
@@ -26,7 +29,7 @@ public struct SwiftPackage: Sendable {
 
 extension SwiftPackage: Encodable {
     enum CodingKeys: String, CodingKey {
-        case package, repositoryURL, revision, version
+        case package, repositoryURL, revision, branch, version
     }
 }
 
@@ -41,13 +44,15 @@ extension SwiftPackage: Hashable {
         hasher.combine(package)
         hasher.combine(repositoryURL)
         hasher.combine(revision)
+        hasher.combine(branch)
         hasher.combine(version)
     }
-    
+
     public static func == (lhs: SwiftPackage, rhs: SwiftPackage) -> Bool {
         return lhs.package == rhs.package &&
                lhs.repositoryURL == rhs.repositoryURL &&
                lhs.revision == rhs.revision &&
+               lhs.branch == rhs.branch &&
                lhs.version == rhs.version
     }
 }
@@ -139,6 +144,7 @@ extension SwiftPackage {
                     package: $0.package,
                     repositoryURL: $0.repositoryURL,
                     revision: $0.state.revision,
+                    branch: $0.state.branch,
                     version: Version($0.state.version ?? "")
                 )
             }
@@ -148,6 +154,7 @@ extension SwiftPackage {
                     package: $0.identity,
                     repositoryURL: $0.location,
                     revision: $0.state.revision,
+                    branch: $0.state.branch,
                     version: Version($0.state.version ?? "")
                 )
             }

--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -186,7 +186,7 @@ extension SwiftPackage {
         }
     }
 
-    public static func collectVersions(for packages: [SwiftPackage], ignoringPrerelease: Bool, onlyMajorUpdates: Bool, checkSecurity: Bool = false) async -> PackageCollection {
+    public static func collectVersions(for packages: [SwiftPackage], ignoringPrerelease: Bool, onlyMajorUpdates: Bool, checkSecurity: Bool = false, checkoutLocator: CheckoutLocator? = nil) async -> PackageCollection {
         log.info("Collecting versions for \(packages.map { $0.package }.joined(separator: ", ")).")
         let versions = await fetchAvailableVersions(for: packages)
 
@@ -216,13 +216,21 @@ extension SwiftPackage {
                         package: package.package,
                         repositoryURL: package.repositoryURL,
                         revision: package.revision,
+                        branch: package.branch,
                         version: package.version
                     )
                 )
             }
         }
 
-        let ignoredPackages = packages.filter { !$0.hasResolvedVersion }
+        // Branch/revision pins: analyze against a local checkout when one is available, otherwise
+        // keep the historical "ignored" behavior.
+        let (refPinnedPackages, ignoredPackages) = await analyzeRefPins(
+            packages.filter { !$0.hasResolvedVersion },
+            ignoringPrerelease: ignoringPrerelease,
+            onlyMajorUpdates: onlyMajorUpdates,
+            checkoutLocator: checkoutLocator
+        )
         if !ignoredPackages.isEmpty {
             log.info("Ignoring \(ignoredPackages.map { $0.package }.joined(separator: ", ")) because of non-version pins.")
         }
@@ -237,8 +245,70 @@ extension SwiftPackage {
             outdatedPackages: outdatedPackages.sorted(),
             ignoredPackages: ignoredPackages.sorted(),
             upToDatePackages: upToDatePackages.sorted(),
-            securityResults: securityResults
+            securityResults: securityResults,
+            refPinnedPackages: refPinnedPackages.sorted()
         )
+    }
+
+    /// For each ref/branch pin, locate its checkout and derive how outdated it is: the base tag comes
+    /// from the local commit graph (`git describe`), the latest from `ls-remote` (fresh). Pins without a
+    /// usable checkout are returned as `ignored`, matching the pre-existing behavior.
+    private static func analyzeRefPins(
+        _ refPinned: [SwiftPackage],
+        ignoringPrerelease: Bool,
+        onlyMajorUpdates: Bool,
+        checkoutLocator: CheckoutLocator?
+    ) async -> (analyses: [RefPinAnalysis], ignored: [SwiftPackage]) {
+        guard let locator = checkoutLocator, !refPinned.isEmpty else {
+            return ([], refPinned)
+        }
+
+        let localGit = ShellLocalGitProvider()
+        let results: [(SwiftPackage, RefPinAnalysis?)] = await withTaskGroup(of: (SwiftPackage, RefPinAnalysis?).self) { group in
+            for package in refPinned {
+                group.addTask {
+                    guard let revision = package.revision,
+                          let checkoutPath = locator.findCheckout(for: package.package, repositoryURL: package.repositoryURL)
+                    else {
+                        return (package, nil)
+                    }
+
+                    let baseTag = ((try? localGit.describeTag(revision: revision, checkoutPath: checkoutPath)) ?? nil)
+                        .flatMap { Version(tolerant: $0) }
+                    let latest = getLatestVersion(
+                        from: package.availableVersions(),
+                        currentVersion: baseTag ?? Version(0, 0, 0),
+                        ignoringPrerelease: ignoringPrerelease,
+                        onlyMajorUpdates: onlyMajorUpdates
+                    )
+                    return (package, RefPinAnalysis(
+                        package: package.package,
+                        branch: package.branch,
+                        revision: revision,
+                        baseTag: baseTag,
+                        latestTag: latest,
+                        url: package.repositoryURL
+                    ))
+                }
+            }
+
+            var out = [(SwiftPackage, RefPinAnalysis?)]()
+            for await result in group {
+                out.append(result)
+            }
+            return out
+        }
+
+        var analyses = [RefPinAnalysis]()
+        var ignored = [SwiftPackage]()
+        for (package, analysis) in results {
+            if let analysis {
+                analyses.append(analysis)
+            } else {
+                ignored.append(package)
+            }
+        }
+        return (analyses, ignored)
     }
 
     /// Collect versions for update mode, returning tuples suitable for PackageUpdater.

--- a/Sources/SwiftOutdated/SwiftOutdated.swift
+++ b/Sources/SwiftOutdated/SwiftOutdated.swift
@@ -42,12 +42,19 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
     @Flag(name: .long, help: "Check packages against OSV and OpenSSF Scorecard for known vulnerabilities.")
     var checkSecurity: Bool = false
 
+    @Option(name: .long, help: "Path to a package checkouts directory (overrides auto-detection of .build/checkouts and SourcePackages/checkouts).")
+    var checkoutsPath: String?
+
     public static let configuration = CommandConfiguration(
         commandName: "swift-outdated",
         abstract: "Check for outdated dependencies.",
         discussion: """
         swift-outdated will output an overview of your outdated dependencies found in your Package.resolved file.
-        Dependencies pinned to specific revisions or branches are ignored (and shown as such).
+
+        Dependencies pinned to a branch or revision are analyzed against their local checkout (from
+        .build/checkouts or an Xcode SourcePackages/checkouts directory) to show the tag they sit at and
+        the latest available version. This happens automatically when a checkout is present; pins without
+        one are shown as ignored, as before.
 
         The latest version for dependencies one major version behind is colored green, yellow for two major versions
         and red for anything above that.
@@ -71,7 +78,8 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
         if let update = update {
             try await runUpdate(scope: update.libScope, folder: folder, pins: pins)
         } else {
-            let packages = await SwiftPackage.collectVersions(for: pins, ignoringPrerelease: ignorePrerelease, onlyMajorUpdates: onlyMajor, checkSecurity: checkSecurity)
+            let checkoutLocator = CheckoutLocator(projectFolder: folder, explicitPath: checkoutsPath)
+            let packages = await SwiftPackage.collectVersions(for: pins, ignoringPrerelease: ignorePrerelease, onlyMajorUpdates: onlyMajor, checkSecurity: checkSecurity, checkoutLocator: checkoutLocator)
             packages.output(format: isRunningInXcode ? .xcode : format.libFormat, includeUpToDatePackages: includeUpToDate)
         }
     }

--- a/Tests/OutdatedTests/CheckoutLocatorTests.swift
+++ b/Tests/OutdatedTests/CheckoutLocatorTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+import Files
+@testable import Outdated
+
+@Suite("Checkout Locator Tests")
+struct CheckoutLocatorTests {
+
+    init() {
+        initializeTestLogging()
+    }
+
+    private func locator() -> CheckoutLocator {
+        CheckoutLocator(projectFolderPath: "/tmp", explicitPath: nil)
+    }
+
+    @Test("URL normalization - HTTPS with .git suffix")
+    func normalizeHTTPSWithGit() {
+        #expect(locator().normalizeURL("https://github.com/user/repo.git") == "github.com/user/repo")
+    }
+
+    @Test("URL normalization - HTTPS without .git suffix")
+    func normalizeHTTPSWithoutGit() {
+        #expect(locator().normalizeURL("https://github.com/user/repo") == "github.com/user/repo")
+    }
+
+    @Test("URL normalization - SSH and HTTPS match")
+    func normalizeSSHMatchesHTTPS() {
+        let l = locator()
+        #expect(l.normalizeURL("git@github.com:user/repo.git") == "github.com/user/repo")
+        #expect(l.normalizeURL("git@github.com:apple/swift-argument-parser.git")
+            == l.normalizeURL("https://github.com/apple/swift-argument-parser.git"))
+    }
+
+    @Test("URL normalization - case insensitive")
+    func normalizeCaseInsensitive() {
+        let l = locator()
+        #expect(l.normalizeURL("https://github.com/user/repo") == l.normalizeURL("https://GitHub.com/User/Repo"))
+    }
+
+    @Test("URL normalization - trailing slash and whitespace")
+    func normalizeTrailingSlashAndWhitespace() {
+        let l = locator()
+        #expect(l.normalizeURL("  https://github.com/user/repo/  \n") == l.normalizeURL("https://github.com/user/repo"))
+    }
+
+    @Test("URL normalization - GitLab SSH and HTTPS match")
+    func normalizeGitLab() {
+        let l = locator()
+        #expect(l.normalizeURL("https://gitlab.com/org/project.git") == l.normalizeURL("git@gitlab.com:org/project.git"))
+    }
+
+    @Test("No checkouts available in empty folder")
+    func noCheckoutsInEmptyFolder() throws {
+        let tempFolder = try Folder.temporary.createSubfolder(named: "test-\(UUID().uuidString)")
+        defer { try? tempFolder.delete() }
+
+        let locator = CheckoutLocator(projectFolder: tempFolder, explicitPath: nil)
+        #expect(locator.hasCheckoutsAvailable() == false)
+        #expect(locator.getCheckoutRoots().isEmpty)
+    }
+
+    @Test("Explicit path replaces auto-detected roots")
+    func explicitPathReplacesRoots() throws {
+        let tempFolder = try Folder.temporary.createSubfolder(named: "test-\(UUID().uuidString)")
+        defer { try? tempFolder.delete() }
+
+        _ = try tempFolder.createSubfolder(at: ".build/checkouts")
+        let explicitCheckouts = try tempFolder.createSubfolder(named: "custom-checkouts")
+
+        let locator = CheckoutLocator(projectFolder: tempFolder, explicitPath: explicitCheckouts.path)
+        let roots = locator.getCheckoutRoots()
+
+        #expect(roots.count == 1)
+        #expect(roots.first?.path == explicitCheckouts.path)
+    }
+
+    @Test("Detects SwiftPM checkouts")
+    func detectsSwiftPMCheckouts() throws {
+        let tempFolder = try Folder.temporary.createSubfolder(named: "test-\(UUID().uuidString)")
+        defer { try? tempFolder.delete() }
+
+        let swiftpmCheckouts = try tempFolder.createSubfolder(at: ".build/checkouts")
+        let locator = CheckoutLocator(projectFolder: tempFolder, explicitPath: nil)
+
+        #expect(locator.getCheckoutRoots().map(\.path) == [swiftpmCheckouts.path])
+        #expect(locator.hasCheckoutsAvailable() == true)
+    }
+
+    @Test("Detects Xcode SourcePackages checkouts")
+    func detectsXcodeCheckouts() throws {
+        let tempFolder = try Folder.temporary.createSubfolder(named: "test-\(UUID().uuidString)")
+        defer { try? tempFolder.delete() }
+
+        let xcodeCheckouts = try tempFolder.createSubfolder(at: "SourcePackages/checkouts")
+        let locator = CheckoutLocator(projectFolder: tempFolder, explicitPath: nil)
+
+        #expect(locator.getCheckoutRoots().map(\.path) == [xcodeCheckouts.path])
+    }
+
+    @Test("Detects both SwiftPM and Xcode checkouts")
+    func detectsBothCheckoutTypes() throws {
+        let tempFolder = try Folder.temporary.createSubfolder(named: "test-\(UUID().uuidString)")
+        defer { try? tempFolder.delete() }
+
+        let swiftpmCheckouts = try tempFolder.createSubfolder(at: ".build/checkouts")
+        let xcodeCheckouts = try tempFolder.createSubfolder(at: "SourcePackages/checkouts")
+
+        let locator = CheckoutLocator(projectFolder: tempFolder, explicitPath: nil)
+        let roots = locator.getCheckoutRoots()
+
+        #expect(roots.count == 2)
+        #expect(roots.contains { $0.path == swiftpmCheckouts.path })
+        #expect(roots.contains { $0.path == xcodeCheckouts.path })
+    }
+}

--- a/Tests/OutdatedTests/LocalGitProviderTests.swift
+++ b/Tests/OutdatedTests/LocalGitProviderTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+import Files
+@testable import Outdated
+
+@Suite("Local Git Provider Tests")
+struct LocalGitProviderTests {
+
+    init() {
+        initializeTestLogging()
+    }
+
+    /// Runs git in an isolated environment (no user/global config, no signing) and returns stdout.
+    @discardableResult
+    private func git(_ args: [String], in dir: String) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", dir,
+                             "-c", "user.email=test@example.com",
+                             "-c", "user.name=Test",
+                             "-c", "commit.gpgsign=false"] + args
+        var env = ProcessInfo.processInfo.environment
+        env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+        process.environment = env
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        guard process.terminationStatus == 0 else {
+            throw GitTestError.commandFailed(args.joined(separator: " "), status: process.terminationStatus)
+        }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    enum GitTestError: Error { case commandFailed(String, status: Int32) }
+
+    /// Builds a repo: commit A (untagged) → commit B (tagged 1.0.0) → commit C (untagged HEAD).
+    private func makeRepo() throws -> (path: String, cleanup: () -> Void, shaA: String) {
+        let folder = try Folder.temporary.createSubfolder(named: "refpin-\(UUID().uuidString)")
+        let path = folder.path
+        try git(["init", "-q"], in: path)
+        try folder.createFile(named: "a.txt").write("a")
+        try git(["add", "."], in: path)
+        try git(["commit", "-q", "-m", "A"], in: path)
+        let shaA = try git(["rev-parse", "HEAD"], in: path)
+        try folder.createFile(named: "b.txt").write("b")
+        try git(["add", "."], in: path)
+        try git(["commit", "-q", "-m", "B"], in: path)
+        try git(["tag", "1.0.0"], in: path)
+        try folder.createFile(named: "c.txt").write("c")
+        try git(["add", "."], in: path)
+        try git(["commit", "-q", "-m", "C"], in: path)
+        return (path, { try? folder.delete() }, shaA)
+    }
+
+    @Test("describeTag resolves the nearest ancestor tag")
+    func describeTagResolvesAncestorTag() throws {
+        let repo = try makeRepo()
+        defer { repo.cleanup() }
+
+        let provider = ShellLocalGitProvider()
+        // HEAD (commit C) and the tagged commit B both have 1.0.0 as nearest ancestor tag.
+        #expect(try provider.describeTag(revision: "HEAD", checkoutPath: repo.path) == "1.0.0")
+    }
+
+    @Test("describeTag throws when the revision has no ancestor tag")
+    func describeTagThrowsWithoutAncestorTag() throws {
+        let repo = try makeRepo()
+        defer { repo.cleanup() }
+
+        let provider = ShellLocalGitProvider()
+        // Commit A precedes the only tag, so there is no tag at or before it.
+        #expect(throws: (any Error).self) {
+            try provider.describeTag(revision: repo.shaA, checkoutPath: repo.path)
+        }
+    }
+}

--- a/Tests/OutdatedTests/LocalGitProviderTests.swift
+++ b/Tests/OutdatedTests/LocalGitProviderTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import Files
+import Version
 @testable import Outdated
 
 @Suite("Local Git Provider Tests")
@@ -77,5 +78,58 @@ struct LocalGitProviderTests {
         #expect(throws: (any Error).self) {
             try provider.describeTag(revision: repo.shaA, checkoutPath: repo.path)
         }
+    }
+
+    @Test("collectVersions analyzes a ref pin against a real local checkout")
+    func collectVersionsAnalyzesRefPin() async throws {
+        // A project dir containing a real checkout under .build/checkouts/<name>.
+        let project = try Folder.temporary.createSubfolder(named: "proj-\(UUID().uuidString)")
+        defer { try? project.delete() }
+        let checkouts = try project.createSubfolder(at: ".build/checkouts")
+        let checkout = try checkouts.createSubfolder(named: "demo")
+        let path = checkout.path
+        let repoURL = "https://github.com/test/demo.git"
+
+        try git(["init", "-q"], in: path)
+        try git(["remote", "add", "origin", repoURL], in: path)
+        try checkout.createFile(named: "a.txt").write("a")
+        try git(["add", "."], in: path)
+        try git(["commit", "-q", "-m", "A"], in: path)
+        try git(["tag", "1.0.0"], in: path)
+        try checkout.createFile(named: "b.txt").write("b")
+        try git(["add", "."], in: path)
+        try git(["commit", "-q", "-m", "B"], in: path)
+        let headSha = try git(["rev-parse", "HEAD"], in: path)
+
+        // ls-remote (latest) is mocked; the base tag comes from the real checkout above.
+        let mock = MockGitRemoteProvider()
+        mock.setTagRefsResponse(for: repoURL, response: """
+        0000000000000000000000000000000000000000\trefs/tags/1.0.0
+        1111111111111111111111111111111111111111\trefs/tags/2.0.0
+        """)
+        let package = SwiftPackage(
+            package: "demo",
+            repositoryURL: repoURL,
+            revision: headSha,
+            branch: "main",
+            version: nil,
+            gitProvider: mock
+        )
+
+        let collection = await SwiftPackage.collectVersions(
+            for: [package],
+            ignoringPrerelease: false,
+            onlyMajorUpdates: false,
+            checkoutLocator: CheckoutLocator(projectFolder: project, explicitPath: nil)
+        )
+
+        #expect(collection.ignoredPackages.isEmpty)
+        #expect(collection.refPinnedPackages.count == 1)
+        let analysis = try #require(collection.refPinnedPackages.first)
+        #expect(analysis.package == "demo")
+        #expect(analysis.branch == "main")
+        #expect(analysis.baseTag == Version(1, 0, 0))   // describe(HEAD) → 1.0.0
+        #expect(analysis.latestTag == Version(2, 0, 0))  // from mocked ls-remote
+        #expect(analysis.isOutdated == true)
     }
 }

--- a/Tests/OutdatedTests/RefPinAnalysisTests.swift
+++ b/Tests/OutdatedTests/RefPinAnalysisTests.swift
@@ -1,0 +1,128 @@
+import Testing
+import Version
+@testable import Outdated
+
+@Suite("Ref Pin Analysis Tests")
+struct RefPinAnalysisTests {
+
+    init() {
+        initializeTestLogging()
+    }
+
+    @Test("Short revision truncates to 7 characters")
+    func shortRevisionTruncation() {
+        let analysis = RefPinAnalysis(
+            package: "test-package",
+            revision: "abc1234567890def",
+            baseTag: Version(1, 0, 0),
+            latestTag: Version(2, 0, 0),
+            url: "https://github.com/test/repo"
+        )
+        #expect(analysis.shortRevision == "abc1234")
+    }
+
+    @Test("Current display with base tag")
+    func currentDisplayWithBaseTag() {
+        let analysis = RefPinAnalysis(
+            package: "test-package",
+            revision: "abc1234567890def",
+            baseTag: Version(1, 2, 3),
+            latestTag: Version(2, 0, 0),
+            url: "https://github.com/test/repo"
+        )
+        #expect(analysis.currentDisplay == "abc1234 (v1.2.3)")
+    }
+
+    @Test("Current display without base tag")
+    func currentDisplayWithoutBaseTag() {
+        let analysis = RefPinAnalysis(
+            package: "test-package",
+            revision: "abc1234567890def",
+            baseTag: nil,
+            latestTag: Version(2, 0, 0),
+            url: "https://github.com/test/repo"
+        )
+        #expect(analysis.currentDisplay == "abc1234")
+    }
+
+    @Test("Current display includes branch name")
+    func currentDisplayWithBranch() {
+        let analysis = RefPinAnalysis(
+            package: "test-package",
+            branch: "main",
+            revision: "abc1234567890def",
+            baseTag: Version(1, 2, 3),
+            latestTag: Version(2, 0, 0),
+            url: "https://github.com/test/repo"
+        )
+        #expect(analysis.currentDisplay == "main @ abc1234 (v1.2.3)")
+    }
+
+    @Test("Is outdated when latest is newer than base")
+    func isOutdatedWhenLatestNewer() {
+        let analysis = RefPinAnalysis(
+            package: "p", revision: "abc1234",
+            baseTag: Version(1, 0, 0), latestTag: Version(2, 0, 0),
+            url: "https://github.com/test/repo"
+        )
+        #expect(analysis.isOutdated == true)
+    }
+
+    @Test("Is not outdated when latest equals base")
+    func isNotOutdatedWhenLatestEqualsBase() {
+        let analysis = RefPinAnalysis(
+            package: "p", revision: "abc1234",
+            baseTag: Version(2, 0, 0), latestTag: Version(2, 0, 0),
+            url: "https://github.com/test/repo"
+        )
+        #expect(analysis.isOutdated == false)
+    }
+
+    @Test("Is not outdated when base or latest tag is nil")
+    func isNotOutdatedWhenTagNil() {
+        let noBase = RefPinAnalysis(package: "p", revision: "abc", baseTag: nil, latestTag: Version(2, 0, 0), url: "")
+        let noLatest = RefPinAnalysis(package: "p", revision: "abc", baseTag: Version(1, 0, 0), latestTag: nil, url: "")
+        #expect(noBase.isOutdated == false)
+        #expect(noLatest.isOutdated == false)
+    }
+
+    @Test("Sorting by package name")
+    func sortingByPackageName() {
+        let analyses = [
+            RefPinAnalysis(package: "z-package", revision: "abc", baseTag: nil, latestTag: nil, url: ""),
+            RefPinAnalysis(package: "a-package", revision: "abc", baseTag: nil, latestTag: nil, url: ""),
+            RefPinAnalysis(package: "m-package", revision: "abc", baseTag: nil, latestTag: nil, url: ""),
+        ]
+        #expect(analyses.sorted().map(\.package) == ["a-package", "m-package", "z-package"])
+    }
+
+    @Test("Table values include all fields")
+    func tableValuesIncludeAllFields() {
+        let analysis = RefPinAnalysis(
+            package: "test-package",
+            revision: "abc1234567890def",
+            baseTag: Version(1, 0, 0),
+            latestTag: Version(2, 0, 0),
+            url: "https://github.com/test/repo"
+        )
+        let values = analysis.tableValues
+        #expect(values.count == 4)
+        #expect(values[0].description == "test-package")
+        #expect(values[1].description == "abc1234 (v1.0.0)")
+        // values[2] may carry ANSI color codes, so assert on substring.
+        #expect(values[2].description.contains("2.0.0"))
+        #expect(values[3].description.contains("github.com/test/repo"))
+    }
+
+    @Test("Table values show N/A when no latest tag")
+    func tableValuesShowNAWhenNoLatestTag() {
+        let analysis = RefPinAnalysis(
+            package: "test-package",
+            revision: "abc1234567890def",
+            baseTag: Version(1, 0, 0),
+            latestTag: nil,
+            url: "https://github.com/test/repo"
+        )
+        #expect(analysis.tableValues[2].description == "N/A")
+    }
+}

--- a/Tests/OutdatedTests/RefPinAnalysisTests.swift
+++ b/Tests/OutdatedTests/RefPinAnalysisTests.swift
@@ -58,6 +58,32 @@ struct RefPinAnalysisTests {
         #expect(analysis.currentDisplay == "main @ abc1234 (v1.2.3)")
     }
 
+    @Test("Current display omits branch when it is a revision prefix")
+    func currentDisplayOmitsRevisionPrefixBranch() {
+        // `.revision("626c3d4")` makes SwiftPM record the short SHA as the branch.
+        let analysis = RefPinAnalysis(
+            package: "rainbow",
+            branch: "626c3d4",
+            revision: "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
+            baseTag: Version(3, 2, 0),
+            latestTag: Version(4, 2, 1),
+            url: "https://github.com/onevcat/Rainbow.git"
+        )
+        #expect(analysis.currentDisplay == "626c3d4 (v3.2.0)")
+    }
+
+    @Test("Latest display is bare to match the version-pinned rows")
+    func latestDisplayIsBare() {
+        let analysis = RefPinAnalysis(
+            package: "p", revision: "abc1234",
+            baseTag: Version(1, 0, 0), latestTag: Version(2, 0, 0),
+            url: ""
+        )
+        // Shares the Latest column with version-pinned rows (e.g. "1.14.0"), so no "v" prefix.
+        #expect(analysis.latestDisplay.contains("2.0.0"))
+        #expect(!analysis.latestDisplay.contains("v"))
+    }
+
     @Test("Is outdated when latest is newer than base")
     func isOutdatedWhenLatestNewer() {
         let analysis = RefPinAnalysis(

--- a/Tests/OutdatedTests/VersionCollectionTests.swift
+++ b/Tests/OutdatedTests/VersionCollectionTests.swift
@@ -199,4 +199,29 @@ struct VersionCollectionTests {
         #expect(packageCollectionMajorOnly.outdatedPackages.count == 1)
         #expect(packageCollectionMajorOnly.outdatedPackages.first?.latestVersion == Version(3, 0, 0))
     }
+
+    @Test("Ref-pinned packages are ignored when no checkout is available")
+    func refPinnedPackagesAreIgnoredWithoutCheckout() async {
+        let mockProvider = MockGitRemoteProvider()
+        // A branch/revision pin resolves to a revision but has no version.
+        let refPinned = SwiftPackage(
+            package: "RefPinned",
+            repositoryURL: "https://github.com/example/ref-pinned.git",
+            revision: "9f39744e025c7d377987f30b03770805dcb0bcd1",
+            version: nil,
+            gitProvider: mockProvider
+        )
+
+        let collection = await SwiftPackage.collectVersions(
+            for: [refPinned],
+            ignoringPrerelease: false,
+            onlyMajorUpdates: false
+        )
+
+        // Without a checkout locator, ref pins keep the historical behavior:
+        // ignored, never queried, and not surfaced as outdated/up-to-date.
+        #expect(collection.ignoredPackages.map(\.package) == ["RefPinned"])
+        #expect(collection.outdatedPackages.isEmpty)
+        #expect(collection.upToDatePackages.isEmpty)
+    }
 }


### PR DESCRIPTION
Branch/revision-pinned deps used to be silently skipped. Now, when SwiftPM's local checkout is present, swift-outdated shows how outdated the pin is.

Works in all output modes and falls back to the old behavior if no local checkout is present (yet).

```
$ swift outdated
| Package   | Current          | Latest | URL                                    |
|-----------|------------------|--------|----------------------------------------|
| swift-log | 1.6.4            | 1.14.0 | https://github.com/apple/swift-log.git |
| rainbow   | 626c3d4 (v3.2.0) | 4.2.1  | https://github.com/onevcat/Rainbow.git |
```

Closes #43