### PR TITLE
Direct deps default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ $ swift outdated
 
 This lists all your outdated dependencies, the currently resolved version and the latest version available in their upstream repository.
 
+### Direct vs. transitive dependencies
+
+By default `swift-outdated` only reports your project's **direct** dependencies, the ones you declared yourself, via `swift package dump-package` for SwiftPM and Tuist projects, and from the `XCRemoteSwiftPackageReference` entries in `project.pbxproj` for Xcode projects.
+
+Pass `-t` / `--include-transitive` to report transitive dependencies as well. If the direct dependencies can't be determined (for example a project layout without a recognizable manifest), every package is reported.
+
 ### Listing all dependencies
 
 `swift-outdated` also allows listing all your dependencies alongside the ones that are not up to date.

--- a/Sources/Outdated/CheckoutLocator.swift
+++ b/Sources/Outdated/CheckoutLocator.swift
@@ -114,28 +114,6 @@ extension CheckoutLocator {
     /// Normalize a repository URL for comparison, e.g.
     /// `git@github.com:user/repo.git` and `https://github.com/user/repo` both → `github.com/user/repo`.
     func normalizeURL(_ url: String) -> String {
-        var normalized = url.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // SSH shorthand: git@host:owner/repo → host/owner/repo
-        if normalized.hasPrefix("git@") {
-            normalized = String(normalized.dropFirst(4))
-            if let colonIndex = normalized.firstIndex(of: ":") {
-                normalized = String(normalized[..<colonIndex]) + "/" + String(normalized[normalized.index(after: colonIndex)...])
-            }
-        }
-
-        if let protocolRange = normalized.range(of: "://") {
-            normalized = String(normalized[protocolRange.upperBound...])
-        }
-
-        if normalized.hasSuffix(".git") {
-            normalized = String(normalized.dropLast(4))
-        }
-
-        if normalized.hasSuffix("/") {
-            normalized = String(normalized.dropLast())
-        }
-
-        return normalized.lowercased()
+        normalizeRepositoryURL(url)
     }
 }

--- a/Sources/Outdated/DirectDependencyResolver.swift
+++ b/Sources/Outdated/DirectDependencyResolver.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Files
+import ShellOut
+
+/// Runs `swift package dump-package` to obtain a project's manifest as JSON.
+/// Abstracted behind a protocol so tests can inject canned output instead of shelling out.
+public protocol ManifestDumpProvider: Sendable {
+    /// Runs `swift package dump-package --package-path <dir>` and returns its raw JSON output.
+    func dumpPackage(packagePath: String) throws -> Data
+}
+
+public struct ShellManifestDumpProvider: ManifestDumpProvider {
+    public init() {}
+
+    public func dumpPackage(packagePath: String) throws -> Data {
+        log.trace("swift package dump-package --package-path \(packagePath)")
+        let output = try shellOut(
+            to: "swift",
+            arguments: ["package", "dump-package", "--package-path", packagePath]
+        )
+        return Data(output.utf8)
+    }
+}
+
+/// The slice of `swift package dump-package` JSON we care about: the direct dependencies and
+/// their remote URLs. All fields are optional so variant manifest shapes decode instead of throwing.
+private struct DumpedManifest: Decodable {
+    let dependencies: [Dependency]
+
+    struct Dependency: Decodable {
+        // Only source-control deps carry a remote URL; fileSystem/registry deps lack `sourceControl`.
+        let sourceControl: [SourceControl]?
+    }
+    struct SourceControl: Decodable {
+        let identity: String?
+        let location: Location?
+    }
+    struct Location: Decodable {
+        let remote: [Remote]?
+    }
+    struct Remote: Decodable {
+        let urlString: String?
+    }
+}
+
+/// Determines the set of *direct* dependencies of a project, so transitive pins in the flat
+/// `Package.resolved` can be filtered out.
+public struct DirectDependencyResolver: Sendable {
+    private let dumpProvider: ManifestDumpProvider
+
+    public init(dumpProvider: ManifestDumpProvider = ShellManifestDumpProvider()) {
+        self.dumpProvider = dumpProvider
+    }
+
+    /// Normalized repository URLs of the project's direct dependencies.
+    ///
+    /// Returns `nil` when direct dependencies cannot be determined (unknown project type, a failed
+    /// `dump-package`, or an unreadable pbxproj) so callers can tell "could not determine, show
+    /// everything" apart from an empty set, which means "determined: zero remote direct deps".
+    public func directDependencyURLs(in folder: Folder) -> Set<String>? {
+        guard let type = PackageUpdater.detectProjectType(in: folder) else {
+            log.info("Could not detect project type; cannot determine direct dependencies.")
+            return nil
+        }
+
+        switch type {
+        case .spm(let manifestPath), .tuist(let manifestPath):
+            let dir = (manifestPath as NSString).deletingLastPathComponent
+            do {
+                let data = try dumpProvider.dumpPackage(packagePath: dir)
+                return Self.parseDumpPackageURLs(data)
+            } catch {
+                log.info("swift package dump-package failed: \(error)")
+                return nil
+            }
+        case .xcode(let pbxprojPath):
+            guard let content = try? String(contentsOfFile: pbxprojPath, encoding: .utf8) else {
+                log.info("Could not read \(pbxprojPath); cannot determine direct dependencies.")
+                return nil
+            }
+            return Self.parsePbxprojURLs(content)
+        }
+    }
+
+    // MARK: - Pure parsers
+
+    /// Collect normalized remote URLs from `swift package dump-package` JSON.
+    /// Returns `nil` if the JSON can't be decoded at all.
+    static func parseDumpPackageURLs(_ data: Data) -> Set<String>? {
+        guard let manifest = try? JSONDecoder().decode(DumpedManifest.self, from: data) else {
+            return nil
+        }
+        let urls = manifest.dependencies
+            .compactMap(\.sourceControl).flatMap { $0 }
+            .compactMap(\.location?.remote).flatMap { $0 }
+            .compactMap(\.urlString)
+        return Set(urls.map(normalizeRepositoryURL))
+    }
+
+    /// Collect normalized remote URLs from a project's `project.pbxproj`. `repositoryURL` only
+    /// appears inside `XCRemoteSwiftPackageReference` blocks, which list direct package
+    /// dependencies — transitive deps are not recorded in the pbxproj.
+    static func parsePbxprojURLs(_ pbxproj: String) -> Set<String> {
+        let pattern = #"repositoryURL\s*=\s*"([^"]+)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(pbxproj.startIndex..., in: pbxproj)
+        let urls = regex.matches(in: pbxproj, range: range).compactMap { match -> String? in
+            guard let urlRange = Range(match.range(at: 1), in: pbxproj) else { return nil }
+            return normalizeRepositoryURL(String(pbxproj[urlRange]))
+        }
+        return Set(urls)
+    }
+}

--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -186,7 +186,17 @@ extension SwiftPackage {
         }
     }
 
-    public static func collectVersions(for packages: [SwiftPackage], ignoringPrerelease: Bool, onlyMajorUpdates: Bool, checkSecurity: Bool = false, checkoutLocator: CheckoutLocator? = nil) async -> PackageCollection {
+    public static func collectVersions(for allPackages: [SwiftPackage], ignoringPrerelease: Bool, onlyMajorUpdates: Bool, checkSecurity: Bool = false, checkoutLocator: CheckoutLocator? = nil, directDependencyURLs: Set<String>? = nil) async -> PackageCollection {
+        // Filter before any analysis so transitive pins are dropped uniformly — a transitive ref
+        // pin should disappear entirely, not resurface in the "ignored" bucket. A nil set means
+        // direct deps couldn't be determined, so keep every package.
+        let packages = directDependencyURLs.map { urls in
+            allPackages.filter { urls.contains(normalizeRepositoryURL($0.repositoryURL)) }
+        } ?? allPackages
+        if directDependencyURLs != nil {
+            log.info("Reporting \(packages.count) of \(allPackages.count) packages (direct dependencies only).")
+        }
+
         log.info("Collecting versions for \(packages.map { $0.package }.joined(separator: ", ")).")
         let versions = await fetchAvailableVersions(for: packages)
 

--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -190,12 +190,7 @@ extension SwiftPackage {
         // Filter before any analysis so transitive pins are dropped uniformly — a transitive ref
         // pin should disappear entirely, not resurface in the "ignored" bucket. A nil set means
         // direct deps couldn't be determined, so keep every package.
-        let packages = directDependencyURLs.map { urls in
-            allPackages.filter { urls.contains(normalizeRepositoryURL($0.repositoryURL)) }
-        } ?? allPackages
-        if directDependencyURLs != nil {
-            log.info("Reporting \(packages.count) of \(allPackages.count) packages (direct dependencies only).")
-        }
+        let packages = filterToDirectDependencies(allPackages, directDependencyURLs: directDependencyURLs)
 
         log.info("Collecting versions for \(packages.map { $0.package }.joined(separator: ", ")).")
         let versions = await fetchAvailableVersions(for: packages)
@@ -258,6 +253,22 @@ extension SwiftPackage {
             securityResults: securityResults,
             refPinnedPackages: refPinnedPackages.sorted()
         )
+    }
+
+    /// Restrict the pins to direct dependencies. A `nil` set means direct deps couldn't be
+    /// determined, so nothing is filtered. As a safety net, a non-nil set that matches *none* of
+    /// the pins also reports everything: that signals our determination missed (e.g. a Tuist or
+    /// local-package layout whose pins aren't expressed in the inspected manifest), and hiding
+    /// every package would look like the tool is broken.
+    static func filterToDirectDependencies(_ packages: [SwiftPackage], directDependencyURLs: Set<String>?) -> [SwiftPackage] {
+        guard let directURLs = directDependencyURLs else { return packages }
+        let filtered = packages.filter { directURLs.contains(normalizeRepositoryURL($0.repositoryURL)) }
+        guard !filtered.isEmpty || packages.isEmpty else {
+            log.info("Direct dependencies matched no resolved packages; reporting all.")
+            return packages
+        }
+        log.info("Reporting \(filtered.count) of \(packages.count) packages (direct dependencies only).")
+        return filtered
     }
 
     /// For each ref/branch pin, locate its checkout and derive how outdated it is: the base tag comes

--- a/Sources/Outdated/URLNormalization.swift
+++ b/Sources/Outdated/URLNormalization.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Normalize a repository URL for comparison, e.g.
+/// `git@github.com:user/repo.git` and `https://github.com/user/repo` both → `github.com/user/repo`.
+func normalizeRepositoryURL(_ url: String) -> String {
+    var normalized = url.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    // SSH shorthand: git@host:owner/repo → host/owner/repo
+    if normalized.hasPrefix("git@") {
+        normalized = String(normalized.dropFirst(4))
+        if let colonIndex = normalized.firstIndex(of: ":") {
+            normalized = String(normalized[..<colonIndex]) + "/" + String(normalized[normalized.index(after: colonIndex)...])
+        }
+    }
+
+    if let protocolRange = normalized.range(of: "://") {
+        normalized = String(normalized[protocolRange.upperBound...])
+    }
+
+    if normalized.hasSuffix(".git") {
+        normalized = String(normalized.dropLast(4))
+    }
+
+    if normalized.hasSuffix("/") {
+        normalized = String(normalized.dropLast())
+    }
+
+    return normalized.lowercased()
+}

--- a/Sources/SwiftOutdated/SwiftOutdated.swift
+++ b/Sources/SwiftOutdated/SwiftOutdated.swift
@@ -30,6 +30,9 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
     @Flag(name: [ .customShort("u"), .long], help: "Include up to date packages")
     var includeUpToDate: Bool = false
 
+    @Flag(name: [.customShort("t"), .long], help: "Include transitive (dependency-of-dependency) packages; by default only direct dependencies are reported.")
+    var includeTransitive: Bool = false
+
     @Option(name: .long, help: "Update outdated packages (patch, minor, major).")
     var update: CLIUpdateScope?
 
@@ -50,6 +53,11 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
         abstract: "Check for outdated dependencies.",
         discussion: """
         swift-outdated will output an overview of your outdated dependencies found in your Package.resolved file.
+
+        By default only your project's direct dependencies are reported. Transitive dependencies (the
+        dependencies of your dependencies) are determined from the manifest (via swift package dump-package
+        for SwiftPM/Tuist, or the .pbxproj for Xcode projects) and filtered out. Pass --include-transitive
+        to report them as well. When the direct dependencies cannot be determined, every package is shown.
 
         Dependencies pinned to a branch or revision are analyzed against their local checkout (from
         .build/checkouts or an Xcode SourcePackages/checkouts directory) to show the tag they sit at and
@@ -79,7 +87,10 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
             try await runUpdate(scope: update.libScope, folder: folder, pins: pins)
         } else {
             let checkoutLocator = CheckoutLocator(projectFolder: folder, explicitPath: checkoutsPath)
-            let packages = await SwiftPackage.collectVersions(for: pins, ignoringPrerelease: ignorePrerelease, onlyMajorUpdates: onlyMajor, checkSecurity: checkSecurity, checkoutLocator: checkoutLocator)
+            // Default to direct dependencies only. A nil set (couldn't determine, or --include-transitive)
+            // means no filtering, falling back to reporting every pin.
+            let directURLs = includeTransitive ? nil : DirectDependencyResolver().directDependencyURLs(in: folder)
+            let packages = await SwiftPackage.collectVersions(for: pins, ignoringPrerelease: ignorePrerelease, onlyMajorUpdates: onlyMajor, checkSecurity: checkSecurity, checkoutLocator: checkoutLocator, directDependencyURLs: directURLs)
             packages.output(format: isRunningInXcode ? .xcode : format.libFormat, includeUpToDatePackages: includeUpToDate)
         }
     }

--- a/Tests/OutdatedTests/DirectDependencyResolverTests.swift
+++ b/Tests/OutdatedTests/DirectDependencyResolverTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import Outdated
+
+@Suite("DirectDependencyResolver Tests")
+struct DirectDependencyResolverTests {
+
+    init() {
+        initializeTestLogging()
+    }
+
+    // MARK: - swift package dump-package
+
+    @Test("Parses remote URLs from dump-package JSON")
+    func parsesDumpPackageURLs() {
+        let json = """
+        {
+          "dependencies": [
+            {"sourceControl": [{"identity": "swift-log",
+              "location": {"remote": [{"urlString": "https://github.com/apple/swift-log.git"}]}}]},
+            {"sourceControl": [{"identity": "rainbow",
+              "location": {"remote": [{"urlString": "https://github.com/onevcat/Rainbow.git"}]}}]}
+          ]
+        }
+        """
+        let urls = DirectDependencyResolver.parseDumpPackageURLs(Data(json.utf8))
+        #expect(urls == [
+            "github.com/apple/swift-log",
+            "github.com/onevcat/rainbow",
+        ])
+    }
+
+    @Test("Local (fileSystem) dependencies are excluded — they carry no remote URL")
+    func excludesLocalDependencies() {
+        let json = """
+        {
+          "dependencies": [
+            {"sourceControl": [{"identity": "rainbow",
+              "location": {"remote": [{"urlString": "https://github.com/onevcat/Rainbow.git"}]}}]},
+            {"fileSystem": [{"identity": "local-pkg", "path": "/some/local/path"}]}
+          ]
+        }
+        """
+        let urls = DirectDependencyResolver.parseDumpPackageURLs(Data(json.utf8))
+        #expect(urls == ["github.com/onevcat/rainbow"])
+    }
+
+    @Test("Malformed dump-package JSON yields nil, not an empty set")
+    func malformedJSONYieldsNil() {
+        #expect(DirectDependencyResolver.parseDumpPackageURLs(Data("not json".utf8)) == nil)
+    }
+
+    // MARK: - project.pbxproj
+
+    @Test("Parses and dedupes repository URLs from pbxproj remote references")
+    func parsesPbxprojURLs() {
+        // SSH and HTTPS forms of the same repo must collapse to one normalized entry.
+        let pbxproj = """
+        /* Begin XCRemoteSwiftPackageReference section */
+            ABC /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+                isa = XCRemoteSwiftPackageReference;
+                repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+                requirement = { kind = upToNextMajorVersion; minimumVersion = 5.0.0; };
+            };
+            DEF /* XCRemoteSwiftPackageReference "Rainbow" */ = {
+                isa = XCRemoteSwiftPackageReference;
+                repositoryURL = "git@github.com:onevcat/Rainbow.git";
+                requirement = { kind = upToNextMajorVersion; minimumVersion = 3.2.0; };
+            };
+        /* End XCRemoteSwiftPackageReference section */
+        """
+        let urls = DirectDependencyResolver.parsePbxprojURLs(pbxproj)
+        #expect(urls == [
+            "github.com/alamofire/alamofire",
+            "github.com/onevcat/rainbow",
+        ])
+    }
+
+    @Test("A pbxproj with no remote references yields an empty set")
+    func pbxprojWithoutRemotesYieldsEmpty() {
+        #expect(DirectDependencyResolver.parsePbxprojURLs("// no package references here") == [])
+    }
+}

--- a/Tests/OutdatedTests/VersionCollectionTests.swift
+++ b/Tests/OutdatedTests/VersionCollectionTests.swift
@@ -236,7 +236,13 @@ struct VersionCollectionTests {
     @Test("A filtered-out transitive ref pin does not resurface as ignored")
     func transitiveRefPinIsDroppedNotIgnored() async {
         let mockProvider = MockGitRemoteProvider()
-        let refPin = SwiftPackage(
+        let directURL = "https://github.com/example/direct.git"
+        mockProvider.setTagRefsResponse(for: directURL, response: """
+        d945937a1b87e8b2bafb749c8ec53610f337c403	refs/tags/1.0.0
+        626c3d4b6b55354b4af3aa309f998fae9b31a3d9	refs/tags/2.0.0
+        """)
+        let direct = SwiftPackage(package: directURL, repositoryURL: directURL, revision: nil, version: Version(1, 0, 0), gitProvider: mockProvider)
+        let transitiveRefPin = SwiftPackage(
             package: "TransitiveRefPin",
             repositoryURL: "https://github.com/example/transitive-ref.git",
             revision: "9f39744e025c7d377987f30b03770805dcb0bcd1",
@@ -245,13 +251,34 @@ struct VersionCollectionTests {
         )
 
         let collection = await SwiftPackage.collectVersions(
-            for: [refPin],
+            for: [direct, transitiveRefPin],
             ignoringPrerelease: false,
             onlyMajorUpdates: false,
-            directDependencyURLs: [] // determined: no direct deps
+            directDependencyURLs: [normalizeRepositoryURL(directURL)]
         )
+        // The transitive ref pin is dropped outright, not surfaced as ignored.
         #expect(collection.ignoredPackages.isEmpty)
-        #expect(collection.outdatedPackages.isEmpty)
+        #expect(collection.outdatedPackages.map(\.url) == [directURL])
+    }
+
+    @Test("Direct set matching no pins falls back to reporting all")
+    func directSetMatchingNothingReportsAll() async {
+        let mockProvider = MockGitRemoteProvider()
+        let url = "https://github.com/example/repo.git"
+        mockProvider.setTagRefsResponse(for: url, response: """
+        d945937a1b87e8b2bafb749c8ec53610f337c403	refs/tags/1.0.0
+        626c3d4b6b55354b4af3aa309f998fae9b31a3d9	refs/tags/2.0.0
+        """)
+        let package = SwiftPackage(package: "repo", repositoryURL: url, revision: nil, version: Version(1, 0, 0), gitProvider: mockProvider)
+
+        // Mimics a Tuist/local-package layout: pins exist but none match the determined set.
+        let collection = await SwiftPackage.collectVersions(
+            for: [package],
+            ignoringPrerelease: false,
+            onlyMajorUpdates: false,
+            directDependencyURLs: ["github.com/unrelated/elsewhere"]
+        )
+        #expect(collection.outdatedPackages.map(\.url) == [url])
     }
 
     @Test("Ref-pinned packages are ignored when no checkout is available")

--- a/Tests/OutdatedTests/VersionCollectionTests.swift
+++ b/Tests/OutdatedTests/VersionCollectionTests.swift
@@ -200,6 +200,60 @@ struct VersionCollectionTests {
         #expect(packageCollectionMajorOnly.outdatedPackages.first?.latestVersion == Version(3, 0, 0))
     }
 
+    @Test("directDependencyURLs filters out transitive packages")
+    func directDependencyURLsFiltersTransitive() async {
+        let mockProvider = MockGitRemoteProvider()
+        let directURL = "https://github.com/example/direct.git"
+        let transitiveURL = "https://github.com/example/transitive.git"
+        for url in [directURL, transitiveURL] {
+            mockProvider.setTagRefsResponse(for: url, response: """
+            d945937a1b87e8b2bafb749c8ec53610f337c403	refs/tags/1.0.0
+            626c3d4b6b55354b4af3aa309f998fae9b31a3d9	refs/tags/2.0.0
+            """)
+        }
+        let packages = [directURL, transitiveURL].map {
+            SwiftPackage(package: $0, repositoryURL: $0, revision: nil, version: Version(1, 0, 0), gitProvider: mockProvider)
+        }
+
+        let filtered = await SwiftPackage.collectVersions(
+            for: packages,
+            ignoringPrerelease: false,
+            onlyMajorUpdates: false,
+            directDependencyURLs: [normalizeRepositoryURL(directURL)]
+        )
+        #expect(filtered.outdatedPackages.map(\.url) == [directURL])
+
+        // A nil set must report both, matching the pre-filter behavior.
+        let unfiltered = await SwiftPackage.collectVersions(
+            for: packages,
+            ignoringPrerelease: false,
+            onlyMajorUpdates: false,
+            directDependencyURLs: nil
+        )
+        #expect(unfiltered.outdatedPackages.count == 2)
+    }
+
+    @Test("A filtered-out transitive ref pin does not resurface as ignored")
+    func transitiveRefPinIsDroppedNotIgnored() async {
+        let mockProvider = MockGitRemoteProvider()
+        let refPin = SwiftPackage(
+            package: "TransitiveRefPin",
+            repositoryURL: "https://github.com/example/transitive-ref.git",
+            revision: "9f39744e025c7d377987f30b03770805dcb0bcd1",
+            version: nil,
+            gitProvider: mockProvider
+        )
+
+        let collection = await SwiftPackage.collectVersions(
+            for: [refPin],
+            ignoringPrerelease: false,
+            onlyMajorUpdates: false,
+            directDependencyURLs: [] // determined: no direct deps
+        )
+        #expect(collection.ignoredPackages.isEmpty)
+        #expect(collection.outdatedPackages.isEmpty)
+    }
+
     @Test("Ref-pinned packages are ignored when no checkout is available")
     func refPinnedPackagesAreIgnoredWithoutCheckout() async {
         let mockProvider = MockGitRemoteProvider()


### PR DESCRIPTION
Check only direct dependencies by default. Allow checking transitive deps by passing `--include-transitive`/`-t`. 

closes #45 