### PR TITLE
Follow fork upstream

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c90a1e04b1dcdf2ec07a77f7354af86335ddb10b0324fdc34ffeb0cbdd8ae5e0",
+  "originHash" : "57cb387acc8e33c43b970e092f8d90b301eebcd52fbd25bdd71f61c78829df8e",
   "pins" : [
     {
       "identity" : "files",
@@ -62,6 +62,15 @@
       "state" : {
         "revision" : "3043fcd2a50375db76d89ff206a612471833d1c2",
         "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "57cb387acc8e33c43b970e092f8d90b301eebcd52fbd25bdd71f61c78829df8e",
+  "originHash" : "3b2b26058e06230902ff05d292ff2ed7c81c915ba7ea2162d5115df9799cfc35",
   "pins" : [
     {
       "identity" : "files",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
-        "version" : "5.4.0"
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/johnsundell/Files.git", from: "4.0.0"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.2.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "6.0.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(url: "https://github.com/johnsundell/Files.git", from: "4.0.0"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.2.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
     ],
     targets: [
         .target(
@@ -34,6 +35,7 @@ let package = Package(
                 "ShellOut",
                 "SwiftyTextTable",
                 "Version",
+                "Yams",
             ]
         ),
         .executableTarget(

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ forks:
     upstream: https://github.com/original/SomeLib.git
 ```
 
-`fork` is matched against the URL in your `Package.resolved` (SSH/HTTPS and a `.git` suffix are treated the same); `upstream` is the repository whose tags then determine the latest version. The dependency is still listed under its own (fork) URL — only the version comparison, including the base/latest tags for branch and revision pins, uses the upstream.
+`fork` is matched against the URL in your `Package.resolved` (SSH/HTTPS and a `.git` suffix are treated the same); `upstream` is the repository whose tags then determine the latest version. The dependency is still listed under its own fork URL, only the version comparison, including the base/latest tags for branch and revision pins, uses the upstream.
 
-Use `--config` / `-c` to point at a config file elsewhere. A malformed config is reported and otherwise ignored.
+Use `--config` / `-c` to point at a config file elsewhere.
 
 ### Branch and revision pins
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A swift subcommand for checking if your dependencies have an update available. T
 
 Calling `swift package update` will only update to the latest available requirements inside your specified version requirements, which totally makes sense, but you might miss that there's a new major version available if you don't check the dependency's repository regularly.
 
-This tool aims to help with that by allowing you to quickly check the remote git tags of your dependencies to see if something outside of your version requirements is available. It also aims to be smart regarding dependencies that are pinned to a branch or a specific revision, not checking transitive dependencies, checking for known security vulnerabilities, and supporting SwiftPM, Tuist and plain Xcode projects.
+This tool aims to help with that by allowing you to quickly check the remote git tags of your dependencies to see if something outside of your version requirements is available. It also aims to be smart regarding dependencies that are pinned to a branch or a specific revision, not checking transitive dependencies, following forks to their upstream, checking for known security vulnerabilities, and supporting SwiftPM, Tuist and plain Xcode projects.
 
 This project is very much inspired by [cargo-outdated](https://github.com/kbknapp/cargo-outdated).
 
@@ -60,6 +60,20 @@ $ swift outdated -u
 | swift-log | 1.14.0  | ✓      | https://github.com/apple/swift-log.git |
 | somepin   | abc1234 | ?      | https://github.com/example/somepin.git |
 ```
+
+### Following a fork's upstream
+
+If a dependency is a fork of another project, the fork's own repository often carries no new tags, so it looks up to date even when the original (upstream) project has shipped newer releases. You can tell `swift-outdated` to measure outdatedness against the upstream instead, via a `.swift-outdated.yml` file in your project directory:
+
+```yaml
+forks:
+  - fork: https://github.com/mycompany/SomeLib.git
+    upstream: https://github.com/original/SomeLib.git
+```
+
+`fork` is matched against the URL in your `Package.resolved` (SSH/HTTPS and a `.git` suffix are treated the same); `upstream` is the repository whose tags then determine the latest version. The dependency is still listed under its own (fork) URL — only the version comparison, including the base/latest tags for branch and revision pins, uses the upstream.
+
+Use `--config` / `-c` to point at a config file elsewhere. A malformed config is reported and otherwise ignored.
 
 ### Branch and revision pins
 

--- a/Sources/Outdated/OutdatedConfig.swift
+++ b/Sources/Outdated/OutdatedConfig.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Files
+import Yams
+
+/// Optional `.swift-outdated.yml` in the project root. Currently only carries fork→upstream
+/// mappings, but the list-of-objects shape leaves room for per-entry options and further keys.
+public struct OutdatedConfig: Decodable {
+    public var forks: [ForkMapping]
+
+    public struct ForkMapping: Decodable {
+        /// The fork repository as pinned in Package.resolved (matched by normalized URL).
+        public let fork: String
+        /// The repository whose tags determine outdatedness instead of the fork's.
+        public let upstream: String
+    }
+
+    public init(forks: [ForkMapping] = []) {
+        self.forks = forks
+    }
+
+    public static func parse(_ yaml: String) throws -> OutdatedConfig {
+        try YAMLDecoder().decode(OutdatedConfig.self, from: yaml)
+    }
+
+    /// `normalized fork URL → raw upstream URL`. The upstream is passed verbatim to `git
+    /// ls-remote`, so it is kept unnormalized; only the lookup key is normalized for matching.
+    public func forkUpstreamMap() -> [String: String] {
+        Dictionary(
+            forks.map { (normalizeRepositoryURL($0.fork), $0.upstream) },
+            // Last mapping wins on duplicate forks rather than crashing.
+            uniquingKeysWith: { _, last in last }
+        )
+    }
+
+    /// An absent config is normal (empty result); a present-but-broken one is logged rather than
+    /// failing the run, matching the tool's resilient, non-fatal style.
+    public static func load(in folder: Folder, explicitPath: String?) -> OutdatedConfig {
+        guard let file = configFile(in: folder, explicitPath: explicitPath) else {
+            return OutdatedConfig()
+        }
+        do {
+            return try parse(try file.readAsString())
+        } catch {
+            log.error("Could not read config at \(file.path): \(error)")
+            return OutdatedConfig()
+        }
+    }
+
+    private static func configFile(in folder: Folder, explicitPath: String?) -> File? {
+        if let explicitPath {
+            guard let file = try? File(path: explicitPath) else {
+                log.error("Config file not found at \(explicitPath)")
+                return nil
+            }
+            return file
+        }
+        return [".swift-outdated.yml", ".swift-outdated.yaml"]
+            .lazy
+            .compactMap { try? folder.file(named: $0) }
+            .first
+    }
+}

--- a/Sources/Outdated/OutdatedConfig.swift
+++ b/Sources/Outdated/OutdatedConfig.swift
@@ -18,6 +18,15 @@ public struct OutdatedConfig: Decodable {
         self.forks = forks
     }
 
+    private enum CodingKeys: String, CodingKey {
+        case forks
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.forks = try container.decodeIfPresent([ForkMapping].self, forKey: .forks) ?? []
+    }
+
     public static func parse(_ yaml: String) throws -> OutdatedConfig {
         try YAMLDecoder().decode(OutdatedConfig.self, from: yaml)
     }

--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -14,22 +14,26 @@ public struct SwiftPackage: Sendable {
     /// The branch a ref pin tracks, when pinned via `.branch(_:)` rather than a bare revision.
     public let branch: String?
     public let version: Version?
+    /// When set (via the fork config), outdatedness is checked against this repository's tags
+    /// instead of `repositoryURL`'s — for dependencies that are forks of an upstream project.
+    public let upstreamURL: String?
 
     private let gitProvider: GitRemoteProvider
 
-    public init(package: String, repositoryURL: String, revision: String?, branch: String? = nil, version: Version?, gitProvider: GitRemoteProvider = ShellGitRemoteProvider()) {
+    public init(package: String, repositoryURL: String, revision: String?, branch: String? = nil, version: Version?, upstreamURL: String? = nil, gitProvider: GitRemoteProvider = ShellGitRemoteProvider()) {
         self.package = package
         self.repositoryURL = repositoryURL
         self.revision = revision
         self.branch = branch
         self.version = version
+        self.upstreamURL = upstreamURL
         self.gitProvider = gitProvider
     }
 }
 
 extension SwiftPackage: Encodable {
     enum CodingKeys: String, CodingKey {
-        case package, repositoryURL, revision, branch, version
+        case package, repositoryURL, revision, branch, version, upstreamURL
     }
 }
 
@@ -46,6 +50,7 @@ extension SwiftPackage: Hashable {
         hasher.combine(revision)
         hasher.combine(branch)
         hasher.combine(version)
+        hasher.combine(upstreamURL)
     }
 
     public static func == (lhs: SwiftPackage, rhs: SwiftPackage) -> Bool {
@@ -53,7 +58,8 @@ extension SwiftPackage: Hashable {
                lhs.repositoryURL == rhs.repositoryURL &&
                lhs.revision == rhs.revision &&
                lhs.branch == rhs.branch &&
-               lhs.version == rhs.version
+               lhs.version == rhs.version &&
+               lhs.upstreamURL == rhs.upstreamURL
     }
 }
 
@@ -64,8 +70,10 @@ extension SwiftPackage {
     
     public func availableVersions() -> [Version] {
         do {
-            log.trace("Running git ls-remote for \(self.package).")
-            let lsRemote = try gitProvider.getRemoteTags(repositoryURL: self.repositoryURL)
+            // Forks often lag their upstream's tags, so check the upstream when one is configured.
+            let versionSource = self.upstreamURL ?? self.repositoryURL
+            log.trace("Running git ls-remote for \(self.package) against \(versionSource).")
+            let lsRemote = try gitProvider.getRemoteTags(repositoryURL: versionSource)
             return lsRemote
                 .split(separator: "\n")
                 .map {
@@ -91,7 +99,7 @@ extension SwiftPackage {
         }
     }
     
-    public static func currentPackagePins(in folder: Folder) throws -> [Self] {
+    public static func currentPackagePins(in folder: Folder, forkUpstreams: [String: String] = [:]) throws -> [Self] {
         let file: File = try {
             let possibleRootResolvedPaths = [
                 "Package.resolved",
@@ -145,7 +153,8 @@ extension SwiftPackage {
                     repositoryURL: $0.repositoryURL,
                     revision: $0.state.revision,
                     branch: $0.state.branch,
-                    version: Version($0.state.version ?? "")
+                    version: Version($0.state.version ?? ""),
+                    upstreamURL: forkUpstreams[normalizeRepositoryURL($0.repositoryURL)]
                 )
             }
         } else if let resolvedV2 = try? JSONDecoder().decode(ResolvedV2.self, from: data) {
@@ -155,7 +164,8 @@ extension SwiftPackage {
                     repositoryURL: $0.location,
                     revision: $0.state.revision,
                     branch: $0.state.branch,
-                    version: Version($0.state.version ?? "")
+                    version: Version($0.state.version ?? ""),
+                    upstreamURL: forkUpstreams[normalizeRepositoryURL($0.location)]
                 )
             }
         } else {

--- a/Sources/SwiftOutdated/SwiftOutdated.swift
+++ b/Sources/SwiftOutdated/SwiftOutdated.swift
@@ -48,6 +48,9 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
     @Option(name: .long, help: "Path to a package checkouts directory (overrides auto-detection of .build/checkouts and SourcePackages/checkouts).")
     var checkoutsPath: String?
 
+    @Option(name: [.customShort("c"), .long], help: "Path to a config file (overrides auto-detection of .swift-outdated.yml in the project directory).")
+    var config: String?
+
     public static let configuration = CommandConfiguration(
         commandName: "swift-outdated",
         abstract: "Check for outdated dependencies.",
@@ -81,7 +84,11 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
     public func run() async throws {
         setupLogging()
         let folder = try Folder(path: path)
-        let pins = try SwiftPackage.currentPackagePins(in: folder)
+        let forkUpstreams = OutdatedConfig.load(in: folder, explicitPath: config).forkUpstreamMap()
+        let pins = try SwiftPackage.currentPackagePins(in: folder, forkUpstreams: forkUpstreams)
+        for pin in pins where pin.upstreamURL != nil {
+            log.info("Following upstream \(pin.upstreamURL!) for \(pin.package).")
+        }
 
         if let update = update {
             try await runUpdate(scope: update.libScope, folder: folder, pins: pins)

--- a/Tests/OutdatedTests/OutdatedConfigTests.swift
+++ b/Tests/OutdatedTests/OutdatedConfigTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import Outdated
+
+@Suite("OutdatedConfig Tests")
+struct OutdatedConfigTests {
+
+    init() {
+        initializeTestLogging()
+    }
+
+    @Test("Parses fork mappings from YAML")
+    func parsesForkMappings() throws {
+        let yaml = """
+        forks:
+          - fork: https://github.com/mycompany/SomeLib.git
+            upstream: https://github.com/original/SomeLib.git
+          - fork: https://github.com/mycompany/Other.git
+            upstream: https://github.com/original/Other.git
+        """
+        let config = try OutdatedConfig.parse(yaml)
+        #expect(config.forks.count == 2)
+        #expect(config.forks.first?.fork == "https://github.com/mycompany/SomeLib.git")
+        #expect(config.forks.first?.upstream == "https://github.com/original/SomeLib.git")
+    }
+
+    @Test("Fork keys are normalized; upstreams are kept verbatim")
+    func forkUpstreamMapNormalizesKeys() throws {
+        // SSH and a .git suffix must collapse to the same key a resolved pin normalizes to.
+        let yaml = """
+        forks:
+          - fork: git@github.com:mycompany/SomeLib.git
+            upstream: https://github.com/original/SomeLib.git
+        """
+        let map = try OutdatedConfig.parse(yaml).forkUpstreamMap()
+        #expect(map == ["github.com/mycompany/somelib": "https://github.com/original/SomeLib.git"])
+    }
+
+    @Test("An absent forks key yields an empty map")
+    func emptyConfigYieldsEmptyMap() throws {
+        #expect(try OutdatedConfig.parse("{}").forkUpstreamMap().isEmpty)
+    }
+
+    @Test("Malformed YAML throws")
+    func malformedYAMLThrows() {
+        #expect(throws: (any Error).self) {
+            try OutdatedConfig.parse("forks: [this is: not valid")
+        }
+    }
+}

--- a/Tests/OutdatedTests/VersionCollectionTests.swift
+++ b/Tests/OutdatedTests/VersionCollectionTests.swift
@@ -281,6 +281,41 @@ struct VersionCollectionTests {
         #expect(collection.outdatedPackages.map(\.url) == [url])
     }
 
+    @Test("A configured upstream is queried instead of the fork (issue #44)")
+    func upstreamURLRedirectsVersionLookup() async {
+        let mockProvider = MockGitRemoteProvider()
+        let forkURL = "https://github.com/mycompany/SomeLib.git"
+        let upstreamURL = "https://github.com/original/SomeLib.git"
+        // The fork has no new tags; the upstream has shipped 2.0.0.
+        mockProvider.setTagRefsResponse(for: forkURL, response: """
+        d945937a1b87e8b2bafb749c8ec53610f337c403	refs/tags/1.0.0
+        """)
+        mockProvider.setTagRefsResponse(for: upstreamURL, response: """
+        d945937a1b87e8b2bafb749c8ec53610f337c403	refs/tags/1.0.0
+        626c3d4b6b55354b4af3aa309f998fae9b31a3d9	refs/tags/2.0.0
+        """)
+        let fork = SwiftPackage(
+            package: "SomeLib",
+            repositoryURL: forkURL,
+            revision: nil,
+            version: Version(1, 0, 0),
+            upstreamURL: upstreamURL,
+            gitProvider: mockProvider
+        )
+
+        let collection = await SwiftPackage.collectVersions(
+            for: [fork],
+            ignoringPrerelease: false,
+            onlyMajorUpdates: false
+        )
+
+        // Outdatedness reflects the upstream's 2.0.0, not the fork's stale 1.0.0.
+        #expect(collection.outdatedPackages.count == 1)
+        #expect(collection.outdatedPackages.first?.latestVersion == Version(2, 0, 0))
+        // The reported URL stays the fork — the actual dependency.
+        #expect(collection.outdatedPackages.first?.url == forkURL)
+    }
+
     @Test("Ref-pinned packages are ignored when no checkout is available")
     func refPinnedPackagesAreIgnoredWithoutCheckout() async {
         let mockProvider = MockGitRemoteProvider()


### PR DESCRIPTION
If a dependency is a fork of another project, the fork's own repository often carries no new tags, so it looks up to date even when the original (upstream) project has shipped newer releases. `swift-outdated` can now measure outdatedness against the upstream instead, via a `.swift-outdated.yml` file.

```yaml
forks:
  - fork: https://github.com/mycompany/SomeLib.git
    upstream: https://github.com/original/SomeLib.git
```

Closes #44 