### PR TITLE
Cache tags in Xcode runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,5 +148,6 @@ or set up a Run Script Phase. In the latter case `swift-outdated` emits warnings
 
 <img width="247" alt="Xcode warnings screenshot" src="https://user-images.githubusercontent.com/2625584/104966116-6cedc400-59e0-11eb-9dc0-942f860e9e33.png">
 
-Be aware however that using a Run Script Phase in this way will fetch available versions for all of your dependencies on every build, which will
-increase your build time by a second or two. You're probably better off running this manually every now and then.
+When run inside Xcode, `swift-outdated` caches the fetched versions for an hour (under `~/Library/Caches/swift-outdated/`) so repeated
+builds don't refetch every dependency each time. Pass `--no-cache` to force a fresh fetch. Outside of Xcode the cache is never used, so
+manual runs always report the latest available versions.

--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -140,7 +140,7 @@ extension SwiftPackage {
             .sorted()
     }
 
-    public static func currentPackagePins(in folder: Folder, forkUpstreams: [String: String] = [:]) throws -> [Self] {
+    public static func currentPackagePins(in folder: Folder, forkUpstreams: [String: String] = [:], cache: TagCache? = nil) throws -> [Self] {
         let file: File = try {
             let possibleRootResolvedPaths = [
                 "Package.resolved",
@@ -186,7 +186,13 @@ extension SwiftPackage {
         guard let data = try? file.read() else {
             throw Error.notReadable
         }
-        
+
+        // A cache (Xcode Run Script Phase) decorates the live providers; otherwise they're used directly.
+        let baseGit: GitRemoteProvider = ShellGitRemoteProvider()
+        let baseRegistry: RegistryProvider = HTTPRegistryProvider(projectPath: folder.path)
+        let gitProvider: GitRemoteProvider = cache.map { CachingGitRemoteProvider(wrapped: baseGit, cache: $0) } ?? baseGit
+        let registryProvider: RegistryProvider = cache.map { CachingRegistryProvider(wrapped: baseRegistry, cache: $0) } ?? baseRegistry
+
         if let resolvedV1 = try? JSONDecoder().decode(ResolvedV1.self, from: data) {
             return resolvedV1.object.pins.map {
                 SwiftPackage(
@@ -195,11 +201,12 @@ extension SwiftPackage {
                     revision: $0.state.revision,
                     branch: $0.state.branch,
                     version: Version($0.state.version ?? ""),
-                    upstreamURL: forkUpstreams[normalizeRepositoryURL($0.repositoryURL)]
+                    upstreamURL: forkUpstreams[normalizeRepositoryURL($0.repositoryURL)],
+                    gitProvider: gitProvider,
+                    registryProvider: registryProvider
                 )
             }
         } else if let resolvedV2 = try? JSONDecoder().decode(ResolvedV2.self, from: data) {
-            let registryProvider = HTTPRegistryProvider(projectPath: folder.path)
             return resolvedV2.pins.map { pin in
                 let isRegistry = pin.kind == "registry" || pin.location == nil
                 let location = pin.location ?? ""
@@ -211,6 +218,7 @@ extension SwiftPackage {
                     version: Version(pin.state.version ?? ""),
                     upstreamURL: isRegistry ? nil : forkUpstreams[normalizeRepositoryURL(location)],
                     registryIdentity: isRegistry ? pin.identity : nil,
+                    gitProvider: gitProvider,
                     registryProvider: registryProvider
                 )
             }

--- a/Sources/Outdated/TagCache.swift
+++ b/Sources/Outdated/TagCache.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Short-lived on-disk cache for raw version-fetch responses (the `git ls-remote` text and the
+/// registry release JSON). Running as an Xcode Run Script Phase otherwise refetches every
+/// dependency's versions on every build (issue #4); caching the raw payload keeps all parsing in
+/// `SwiftPackage` while sparing the network round-trips.
+public struct TagCache: Sendable {
+    public static let defaultTTL: TimeInterval = 3600
+
+    let directory: URL
+    let ttl: TimeInterval
+    // Injectable so tests can simulate expiry; there is no shared clock abstraction to reuse.
+    let now: @Sendable () -> Date
+
+    public init(
+        directory: URL = TagCache.defaultDirectory,
+        ttl: TimeInterval,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.directory = directory
+        self.ttl = ttl
+        self.now = now
+    }
+
+    public static var defaultDirectory: URL {
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        return caches.appendingPathComponent("swift-outdated", isDirectory: true)
+    }
+
+    /// The cached payload for `key`, or `nil` when absent, unreadable, or older than `ttl`.
+    func value(forKey key: String) -> String? {
+        guard let data = try? Data(contentsOf: fileURL(forKey: key)),
+              let entry = try? JSONDecoder().decode(CacheEntry.self, from: data) else {
+            return nil
+        }
+        let age = now().timeIntervalSince1970 - entry.fetchedAt
+        return age < ttl ? entry.payload : nil
+    }
+
+    /// Best-effort write; a cache failure must never fail the run, so errors are swallowed.
+    func store(_ payload: String, forKey key: String) {
+        let entry = CacheEntry(fetchedAt: now().timeIntervalSince1970, payload: payload)
+        guard let data = try? JSONEncoder().encode(entry) else { return }
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? data.write(to: fileURL(forKey: key), options: .atomic)
+    }
+
+    /// URL-safe Base64 of the key keeps the filename deterministic and collision-free without a
+    /// crypto dependency (keys are short git URLs / registry identities).
+    private func fileURL(forKey key: String) -> URL {
+        let name = Data(key.utf8).base64EncodedString()
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "+", with: "-")
+        return directory.appendingPathComponent(name).appendingPathExtension("json")
+    }
+
+    private struct CacheEntry: Codable {
+        let fetchedAt: Double
+        let payload: String
+    }
+}
+
+/// Wraps a `GitRemoteProvider`, serving cached `ls-remote` output within the TTL and otherwise
+/// fetching and caching it.
+struct CachingGitRemoteProvider: GitRemoteProvider {
+    let wrapped: GitRemoteProvider
+    let cache: TagCache
+
+    func getRemoteTags(repositoryURL: String) throws -> String {
+        let key = "git:" + repositoryURL
+        if let cached = cache.value(forKey: key) {
+            log.trace("Cache hit for tags of \(repositoryURL)")
+            return cached
+        }
+        let fresh = try wrapped.getRemoteTags(repositoryURL: repositoryURL)
+        cache.store(fresh, forKey: key)
+        return fresh
+    }
+}
+
+/// Wraps a `RegistryProvider`, serving cached release JSON within the TTL. The payload is JSON text,
+/// so it round-trips through the string-backed cache as UTF-8.
+struct CachingRegistryProvider: RegistryProvider {
+    let wrapped: RegistryProvider
+    let cache: TagCache
+
+    func listReleases(identity: String) throws -> Data {
+        let key = "registry:" + identity
+        if let cached = cache.value(forKey: key) {
+            log.trace("Cache hit for releases of \(identity)")
+            return Data(cached.utf8)
+        }
+        let fresh = try wrapped.listReleases(identity: identity)
+        cache.store(String(decoding: fresh, as: UTF8.self), forKey: key)
+        return fresh
+    }
+}

--- a/Sources/SwiftOutdated/SwiftOutdated.swift
+++ b/Sources/SwiftOutdated/SwiftOutdated.swift
@@ -51,6 +51,9 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
     @Option(name: [.customShort("c"), .long], help: "Path to a config file (overrides auto-detection of .swift-outdated.yml in the project directory).")
     var config: String?
 
+    @Flag(name: .long, help: "Bypass the tag cache used during Xcode builds and always fetch fresh.")
+    var noCache: Bool = false
+
     public static let configuration = CommandConfiguration(
         commandName: "swift-outdated",
         abstract: "Check for outdated dependencies.",
@@ -71,7 +74,8 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
         and red for anything above that.
 
         swift-outdated automatically detects if it is run via an Xcode run script phase and will emit warnings for
-        Xcode's issue navigator.
+        Xcode's issue navigator. In that case fetched versions are cached for an hour so repeated builds don't
+        refetch every dependency; pass --no-cache to bypass it.
 
         Use --update to automatically update outdated packages:
           swift-outdated --update patch    Update to latest patch versions
@@ -85,7 +89,9 @@ public struct SwiftOutdated: AsyncParsableCommand, Sendable {
         setupLogging()
         let folder = try Folder(path: path)
         let forkUpstreams = OutdatedConfig.load(in: folder, explicitPath: config).forkUpstreamMap()
-        let pins = try SwiftPackage.currentPackagePins(in: folder, forkUpstreams: forkUpstreams)
+        // Cache fetched versions across the frequent rebuilds of an Xcode Run Script Phase (issue #4).
+        let cache = (isRunningInXcode && !noCache) ? TagCache(ttl: TagCache.defaultTTL) : nil
+        let pins = try SwiftPackage.currentPackagePins(in: folder, forkUpstreams: forkUpstreams, cache: cache)
         for pin in pins where pin.upstreamURL != nil {
             log.info("Following upstream \(pin.upstreamURL!) for \(pin.package).")
         }

--- a/Tests/OutdatedTests/CachingProviderTests.swift
+++ b/Tests/OutdatedTests/CachingProviderTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import Files
+import Foundation
+@testable import Outdated
+
+@Suite("Caching Provider Tests")
+struct CachingProviderTests {
+
+    init() {
+        initializeTestLogging()
+    }
+
+    private func tempDirectory() throws -> URL {
+        let folder = try Folder.temporary.createSubfolder(named: "swift-outdated-cache-\(UUID().uuidString)")
+        return URL(fileURLWithPath: folder.path)
+    }
+
+    @Test("Git tags are served from the cache within the TTL")
+    func gitCacheHit() throws {
+        let dir = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let cache = TagCache(directory: dir, ttl: 3600, now: { Date(timeIntervalSince1970: 1000) })
+
+        let mock = MockGitRemoteProvider()
+        mock.setTagRefsResponse(for: "https://example.com/repo.git", response: "original")
+        let provider = CachingGitRemoteProvider(wrapped: mock, cache: cache)
+
+        #expect(try provider.getRemoteTags(repositoryURL: "https://example.com/repo.git") == "original")
+
+        // Changing the underlying response proves the second read comes from the cache, not the mock.
+        mock.setTagRefsResponse(for: "https://example.com/repo.git", response: "changed")
+        #expect(try provider.getRemoteTags(repositoryURL: "https://example.com/repo.git") == "original")
+    }
+
+    @Test("Git tags are refetched once the cache entry expires")
+    func gitCacheExpiry() throws {
+        let dir = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mock = MockGitRemoteProvider()
+        mock.setTagRefsResponse(for: "https://example.com/repo.git", response: "original")
+
+        let writer = CachingGitRemoteProvider(
+            wrapped: mock,
+            cache: TagCache(directory: dir, ttl: 3600, now: { Date(timeIntervalSince1970: 1000) })
+        )
+        #expect(try writer.getRemoteTags(repositoryURL: "https://example.com/repo.git") == "original")
+
+        mock.setTagRefsResponse(for: "https://example.com/repo.git", response: "changed")
+        let reader = CachingGitRemoteProvider(
+            wrapped: mock,
+            cache: TagCache(directory: dir, ttl: 3600, now: { Date(timeIntervalSince1970: 1000 + 4000) })
+        )
+        #expect(try reader.getRemoteTags(repositoryURL: "https://example.com/repo.git") == "changed")
+    }
+
+    @Test("Registry release JSON round-trips through the cache intact")
+    func registryCacheHit() throws {
+        let dir = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let cache = TagCache(directory: dir, ttl: 3600, now: { Date(timeIntervalSince1970: 1000) })
+
+        let json = #"{ "releases": { "1.0.0": { "url": "x" } } }"#
+        let mock = MockRegistryProvider()
+        mock.setReleasesResponse(forIdentity: "mona.linkedlist", json: json)
+        let provider = CachingRegistryProvider(wrapped: mock, cache: cache)
+
+        #expect(try provider.listReleases(identity: "mona.linkedlist") == Data(json.utf8))
+
+        mock.setReleasesResponse(forIdentity: "mona.linkedlist", json: #"{ "releases": {} }"#)
+        #expect(try provider.listReleases(identity: "mona.linkedlist") == Data(json.utf8))
+    }
+}

--- a/Tests/OutdatedTests/TagCacheTests.swift
+++ b/Tests/OutdatedTests/TagCacheTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Files
+import Foundation
+@testable import Outdated
+
+@Suite("Tag Cache Tests")
+struct TagCacheTests {
+
+    init() {
+        initializeTestLogging()
+    }
+
+    private func tempDirectory() throws -> URL {
+        let folder = try Folder.temporary.createSubfolder(named: "swift-outdated-cache-\(UUID().uuidString)")
+        return URL(fileURLWithPath: folder.path)
+    }
+
+    @Test("A stored value is returned within the TTL")
+    func hitWithinTTL() throws {
+        let dir = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let cache = TagCache(directory: dir, ttl: 3600, now: { Date(timeIntervalSince1970: 1000) })
+
+        cache.store("refs/tags/1.0.0", forKey: "git:example")
+        #expect(cache.value(forKey: "git:example") == "refs/tags/1.0.0")
+    }
+
+    @Test("A value older than the TTL is treated as a miss")
+    func expiry() throws {
+        let dir = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let writer = TagCache(directory: dir, ttl: 3600, now: { Date(timeIntervalSince1970: 1000) })
+        writer.store("payload", forKey: "git:example")
+
+        // Same directory, but the clock has advanced past the TTL.
+        let reader = TagCache(directory: dir, ttl: 3600, now: { Date(timeIntervalSince1970: 1000 + 4000) })
+        #expect(reader.value(forKey: "git:example") == nil)
+    }
+
+    @Test("A missing key yields nil")
+    func missingKey() throws {
+        let dir = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let cache = TagCache(directory: dir, ttl: 3600)
+        #expect(cache.value(forKey: "git:absent") == nil)
+    }
+
+    @Test("A nonexistent directory yields nil without throwing")
+    func nonexistentDirectory() {
+        let dir = URL(fileURLWithPath: "/nonexistent/swift-outdated-\(UUID().uuidString)")
+        let cache = TagCache(directory: dir, ttl: 3600)
+        #expect(cache.value(forKey: "git:example") == nil)
+    }
+}


### PR DESCRIPTION
When running as an Xcode run script phase, Swift Outdated will cache its results for an hour so as not to clobber remotes and keep local build times fast.

This does not apply to manual runs in the CLI and can also be disabled by passing `--no-cache`.

closes #4 