### PR TITLE
Better handling for non-interactive git sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,14 @@ or set up a Run Script Phase. In the latter case `swift-outdated` emits warnings
 When run inside Xcode, `swift-outdated` caches the fetched versions for an hour (under `~/Library/Caches/swift-outdated/`) so repeated
 builds don't refetch every dependency each time. Pass `--no-cache` to force a fresh fetch. Outside of Xcode the cache is never used, so
 manual runs always report the latest available versions.
+
+### Private dependencies
+
+Checking a dependency's versions runs `git ls-remote` against its repository. A private repository that requires authentication will not allow
+`swift-outdated` to fetch its tags, so the dependency is listed with `?` as its latest version.
+
+To have private dependencies resolved as well, make sure git can authenticate without prompting:
+
+- For password-protected SSH keys, load the key into `ssh-agent` first (`eval "$(ssh-agent)"; ssh-add ~/.ssh/your_key`).
+- For private HTTPS repositories, configure a git credential helper that can answer without a prompt, for example
+  `git config --global credential.helper osxkeychain`.

--- a/Sources/Outdated/GitRemoteProvider.swift
+++ b/Sources/Outdated/GitRemoteProvider.swift
@@ -10,8 +10,36 @@ public struct ShellGitRemoteProvider: GitRemoteProvider {
 
     public func getRemoteTags(repositoryURL: String) throws -> String {
         log.trace("git ls-remote --tags \(repositoryURL)")
-        return try shellOut(to: "git", arguments: ["ls-remote", "--tags", repositoryURL])
+        // Fail fast instead of blocking on an invisible credential/passphrase prompt (issues #17, #30).
+        // A fresh Process per call keeps the concurrent fetches independent; ShellOut leaves the
+        // environment and stdin we set here untouched.
+        let process = Process()
+        process.environment = nonInteractiveGitEnvironment(base: ProcessInfo.processInfo.environment)
+        process.standardInput = FileHandle.nullDevice
+        return try shellOut(to: "git", arguments: ["ls-remote", "--tags", repositoryURL], process: process)
     }
+}
+
+/// `GIT_TERMINAL_PROMPT=0` blocks the HTTPS `Username for …` prompt (#30); ssh `BatchMode=yes` blocks the
+/// key-passphrase and host-key prompts (#17). An existing `GIT_SSH_COMMAND` is preserved and extended.
+func nonInteractiveGitEnvironment(base: [String: String]) -> [String: String] {
+    var env = base
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    let ssh = env["GIT_SSH_COMMAND"] ?? "ssh"
+    env["GIT_SSH_COMMAND"] = ssh.contains("BatchMode") ? ssh : ssh + " -oBatchMode=yes"
+    return env
+}
+
+/// Turns an auth-shaped git failure into an actionable hint (rather than leaving the user stuck, as #17
+/// asked), or `nil` for unrelated failures. Takes the raw stderr text so it's decoupled from
+/// `ShellOutError` and easy to test.
+func gitAuthHint(stderr: String) -> String? {
+    let text = stderr.lowercased()
+    let markers = ["authentication failed", "permission denied", "could not read username",
+                   "terminal prompts disabled", "host key verification failed", "publickey"]
+    guard markers.contains(where: text.contains) else { return nil }
+    return "authentication was required. Use ssh-agent (ssh-add) for password-protected SSH keys, or a "
+         + "credential helper (git config --global credential.helper osxkeychain) for private HTTPS repos."
 }
 
 /// Reads information that requires a *local* clone's commit graph — distinct from

--- a/Sources/Outdated/PackageCollection.swift
+++ b/Sources/Outdated/PackageCollection.swift
@@ -6,11 +6,14 @@ public struct PackageCollection: Encodable {
     public var outdatedPackages: [OutdatedPackage]
     public var ignoredPackages: [SwiftPackage]
     public var upToDatePackages: [SwiftPackage]
+    /// Version-pinned packages whose remote couldn't be reached (typically a private repo needing
+    /// credentials); their latest version is unknown, not confirmed up to date.
+    public var unknownPackages: [SwiftPackage] = []
     public var securityResults: [String: SecurityPair]?
     public var refPinnedPackages: [RefPinAnalysis] = []
 
     enum CodingKeys: String, CodingKey {
-        case outdatedPackages, ignoredPackages, upToDatePackages, securityResults, refPinnedPackages
+        case outdatedPackages, ignoredPackages, upToDatePackages, unknownPackages, securityResults, refPinnedPackages
     }
 }
 
@@ -23,6 +26,7 @@ extension PackageCollection {
 
     public func output(format: OutputFormat, includeUpToDatePackages: Bool = false) {
         guard !self.outdatedPackages.isEmpty || !self.ignoredPackages.isEmpty || !self.refPinnedPackages.isEmpty
+            || !self.unknownPackages.isEmpty
             || (includeUpToDatePackages && !self.upToDatePackages.isEmpty) else { return }
 
         switch format {
@@ -40,6 +44,9 @@ extension PackageCollection {
                 let latest = $0.latestTag.map { "v\($0)" } ?? "a newer tag"
                 print("warning: Dependency \"\($0.package)\" is pinned to \(pin) at \($0.shortRevision)\(base) but \(latest) is available → \($0.url)")
             }
+            self.unknownPackages.forEach {
+                print("warning: Could not check \"\($0.package)\" for updates, is it a private repository needing credentials? → \($0.displayURL)")
+            }
         case .json:
             let encoder = JSONEncoder()
             encoder.outputFormatting = .prettyPrinted
@@ -54,6 +61,7 @@ extension PackageCollection {
             if let securityResults = securityResults {
                 var rows = outdatedPackages.map { OutdatedPackageWithSecurity(base: $0, security: securityResults[$0.package]).tableValues }
                 rows += refPins.map { refPinSecurityRow($0) }
+                rows += unknownPackages.map { unknownSecurityRow($0) }
                 if includeUpToDatePackages {
                     rows += upToDatePackages.map { upToDateSecurityRow($0) }
                     rows += ignoredPackages.map { ignoredSecurityRow($0) }
@@ -62,6 +70,7 @@ extension PackageCollection {
             } else {
                 var rows = outdatedPackages.map { $0.tableValues }
                 rows += refPins.map { $0.tableValues }
+                rows += unknownPackages.map { unknownRow($0) }
                 if includeUpToDatePackages {
                     rows += upToDatePackages.map { upToDateRow($0) }
                     rows += ignoredPackages.map { ignoredRow($0) }
@@ -126,6 +135,11 @@ extension PackageCollection {
         [pkg.package, pkg.version?.description ?? pkg.revision ?? "N/A", "?".dim, pkg.displayURL.blue]
     }
 
+    /// A version-pinned package whose remote couldn't be reached: current version is known, latest isn't.
+    private func unknownRow(_ pkg: SwiftPackage) -> [CustomStringConvertible] {
+        [pkg.package, pkg.version?.description ?? pkg.revision ?? "N/A", "?".dim, pkg.displayURL.blue]
+    }
+
     /// Up-to-date packages aren't security-scanned, so the CVE/score cells are unknown.
     private func upToDateSecurityRow(_ pkg: SwiftPackage) -> [CustomStringConvertible] {
         [pkg.package, pkg.version?.description ?? pkg.revision ?? "N/A", "?".dim, "✓".green, "?".dim, "?".dim, pkg.displayURL.blue]
@@ -133,6 +147,12 @@ extension PackageCollection {
 
     /// Ignored pins are neither analyzed nor security-scanned, so every derived cell is unknown.
     private func ignoredSecurityRow(_ pkg: SwiftPackage) -> [CustomStringConvertible] {
+        [pkg.package, pkg.version?.description ?? pkg.revision ?? "N/A", "?".dim, "?".dim, "?".dim, "?".dim, pkg.displayURL.blue]
+    }
+
+    /// An unreachable version-pinned package can't be security-scanned either, so latest and every
+    /// security cell is unknown; only its current version is known.
+    private func unknownSecurityRow(_ pkg: SwiftPackage) -> [CustomStringConvertible] {
         [pkg.package, pkg.version?.description ?? pkg.revision ?? "N/A", "?".dim, "?".dim, "?".dim, "?".dim, pkg.displayURL.blue]
     }
 

--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -118,7 +118,12 @@ extension SwiftPackage {
                 .compactMap { Version(tolerant: $0) }
                 .sorted()
         } catch {
-            log.error("Error on git ls-remote for \(package): \(error)")
+            let stderr = (error as? ShellOutError)?.message ?? "\(error)"
+            if let hint = gitAuthHint(stderr: stderr) {
+                log.warning("Skipping \(package): \(hint)")
+            } else {
+                log.error("Error on git ls-remote for \(package): \(error)")
+            }
             return []
         }
     }

--- a/Sources/Outdated/SwiftPackage.swift
+++ b/Sources/Outdated/SwiftPackage.swift
@@ -265,6 +265,7 @@ extension SwiftPackage {
         let versions = await fetchAvailableVersions(for: packages)
 
         var upToDatePackages: [SwiftPackage] = []
+        var unknownPackages: [SwiftPackage] = []
         var outdatedPackages: [OutdatedPackage] = []
 
         for (package, allVersions) in versions {
@@ -272,7 +273,22 @@ extension SwiftPackage {
                 continue
             }
 
-            if let latest = getLatestVersion(from: allVersions, currentVersion: current, ignoringPrerelease: ignoringPrerelease, onlyMajorUpdates: onlyMajorUpdates),
+            if allVersions.isEmpty {
+                // No versions came back at all — typically a private repo we couldn't authenticate
+                // against (#17, #30). We haven't confirmed anything, so report the latest as unknown
+                // rather than falsely showing it up to date.
+                log.info("Package \(package.package) has no available versions; latest is unknown.")
+                unknownPackages.append(
+                    SwiftPackage(
+                        package: package.package,
+                        repositoryURL: package.repositoryURL,
+                        revision: package.revision,
+                        branch: package.branch,
+                        version: package.version,
+                        registryIdentity: package.registryIdentity
+                    )
+                )
+            } else if let latest = getLatestVersion(from: allVersions, currentVersion: current, ignoringPrerelease: ignoringPrerelease, onlyMajorUpdates: onlyMajorUpdates),
                current != latest {
                 log.info("Package \(package.package) is outdated.")
                 outdatedPackages.append(
@@ -321,6 +337,7 @@ extension SwiftPackage {
             outdatedPackages: outdatedPackages.sorted(),
             ignoredPackages: ignoredPackages.sorted(),
             upToDatePackages: upToDatePackages.sorted(),
+            unknownPackages: unknownPackages.sorted(),
             securityResults: securityResults,
             refPinnedPackages: refPinnedPackages.sorted()
         )

--- a/Tests/OutdatedTests/GitRemoteProviderTests.swift
+++ b/Tests/OutdatedTests/GitRemoteProviderTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import Outdated
+
+@Suite("Git Remote Provider Tests")
+struct GitRemoteProviderTests {
+
+    init() {
+        initializeTestLogging()
+    }
+
+    @Test("A bare environment gets the non-interactive git/ssh switches")
+    func addsNonInteractiveSwitches() {
+        let env = nonInteractiveGitEnvironment(base: [:])
+        #expect(env["GIT_TERMINAL_PROMPT"] == "0")
+        #expect(env["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes")
+    }
+
+    @Test("An existing GIT_SSH_COMMAND is preserved and extended")
+    func extendsExistingSSHCommand() {
+        let env = nonInteractiveGitEnvironment(base: ["GIT_SSH_COMMAND": "ssh -i key"])
+        #expect(env["GIT_SSH_COMMAND"] == "ssh -i key -oBatchMode=yes")
+    }
+
+    @Test("An ssh command already in batch mode is left unchanged")
+    func leavesBatchModeUntouched() {
+        let env = nonInteractiveGitEnvironment(base: ["GIT_SSH_COMMAND": "ssh -oBatchMode=yes -i key"])
+        #expect(env["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes -i key")
+    }
+
+    @Test("Unrelated environment variables are preserved")
+    func preservesOtherVariables() {
+        let env = nonInteractiveGitEnvironment(base: ["PATH": "/usr/bin"])
+        #expect(env["PATH"] == "/usr/bin")
+    }
+
+    @Test("Auth-shaped failures produce a hint")
+    func authFailuresProduceHint() {
+        // #30: private HTTPS repo with prompts disabled.
+        #expect(gitAuthHint(stderr: "fatal: could not read Username for 'https://github.com': terminal prompts disabled") != nil)
+        // #17: password-protected SSH key.
+        #expect(gitAuthHint(stderr: "git@github.com: Permission denied (publickey).") != nil)
+        #expect(gitAuthHint(stderr: "Host key verification failed.") != nil)
+    }
+
+    @Test("Unrelated failures produce no hint")
+    func unrelatedFailuresProduceNoHint() {
+        #expect(gitAuthHint(stderr: "fatal: repository not found") == nil)
+    }
+}

--- a/Tests/OutdatedTests/VersionCollectionTests.swift
+++ b/Tests/OutdatedTests/VersionCollectionTests.swift
@@ -340,4 +340,27 @@ struct VersionCollectionTests {
         #expect(collection.outdatedPackages.isEmpty)
         #expect(collection.upToDatePackages.isEmpty)
     }
+
+    @Test("A version pin whose remote can't be reached is reported as unknown, not up to date")
+    func unreachableVersionPinIsUnknown() async {
+        // An unconfigured mock throws, mirroring a private repo whose fetch fails (issues #17, #30):
+        // availableVersions() then yields no versions.
+        let package = SwiftPackage(
+            package: "Private",
+            repositoryURL: "https://github.com/example/private.git",
+            revision: nil,
+            version: Version(1, 0, 0),
+            gitProvider: MockGitRemoteProvider()
+        )
+
+        let collection = await SwiftPackage.collectVersions(
+            for: [package],
+            ignoringPrerelease: false,
+            onlyMajorUpdates: false
+        )
+
+        #expect(collection.unknownPackages.map(\.package) == ["Private"])
+        #expect(collection.upToDatePackages.isEmpty)
+        #expect(collection.outdatedPackages.isEmpty)
+    }
 }


### PR DESCRIPTION
Checking a dependency's versions runs `git ls-remote` against its repository. A private repository that requires authentication will not allow `swift-outdated` to fetch its tags, so the dependency is now listed with `?` as its latest version. `swift-outdated` also outputs a warning message about not being able to access that data with possible workarounds.

closes #17 and #30 